### PR TITLE
Fix clippy warnings in tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --no-deps --all-features --examples -- -D warnings
+          args: --no-deps --all-features --examples --tests -- -D warnings
 
   format:
     name: Format

--- a/rechannel/src/channel/block.rs
+++ b/rechannel/src/channel/block.rs
@@ -503,9 +503,9 @@ mod tests {
         let mut channel = BlockChannel::new(BlockChannelConfig::default());
         let first_message = Bytes::from(vec![1, 1, 1, 1]);
         let second_message = Bytes::from(vec![2, 2, 2, 2]);
-        channel.send_message(Bytes::from(first_message.clone()));
+        channel.send_message(first_message.clone());
         // Add second message to queue
-        channel.send_message(Bytes::from(second_message.clone()));
+        channel.send_message(second_message.clone());
 
         // First message
         let block_channel_data = channel.get_messages_to_send(u64::MAX, 0).unwrap();

--- a/rechannel/src/channel/reliable.rs
+++ b/rechannel/src/channel/reliable.rs
@@ -320,7 +320,7 @@ mod tests {
         assert!(!channel.has_messages_to_send());
         assert_eq!(channel.num_messages_sent, 0);
 
-        channel.send_message(TestMessages::Second(0).serialize().into());
+        channel.send_message(TestMessages::Second(0).serialize());
         assert_eq!(channel.num_messages_sent, 1);
         assert!(channel.receive_message().is_none());
 
@@ -393,8 +393,10 @@ mod tests {
 
     #[test]
     fn resend_message() {
-        let mut config = ReliableChannelConfig::default();
-        config.message_resend_time = Duration::from_millis(100);
+        let config = ReliableChannelConfig {
+            message_resend_time: Duration::from_millis(100),
+            ..Default::default()
+        };
         let mut channel: ReliableChannel = ReliableChannel::new(config);
 
         channel.send_message(TestMessages::First.serialize());

--- a/rechannel/src/sequence_buffer.rs
+++ b/rechannel/src/sequence_buffer.rs
@@ -169,8 +169,7 @@ mod tests {
     }
 
     fn count_entries(buffer: &SequenceBuffer<DataStub>) -> usize {
-        let nums: Vec<&u16> = buffer.entry_sequences.iter().flatten().collect();
-        nums.len()
+        buffer.entry_sequences.iter().flatten().count()
     }
 
     #[test]

--- a/renetcode/src/token.rs
+++ b/renetcode/src/token.rs
@@ -362,7 +362,7 @@ mod tests {
         let xnonce = generate_random_bytes();
         token.encode(&mut buffer, protocol_id, expire_timestamp, &xnonce, key).unwrap();
 
-        let result = PrivateConnectToken::decode(&mut buffer, protocol_id, expire_timestamp, &xnonce, key).unwrap();
+        let result = PrivateConnectToken::decode(&buffer, protocol_id, expire_timestamp, &xnonce, key).unwrap();
         assert_eq!(token, result);
     }
 


### PR DESCRIPTION
I noticed that `--tests` flag wasn't enabled for clippy. I enabled it and fixed the discovered warnings.