### PR TITLE
Get server address from socket instead of ServerConfig

### DIFF
--- a/bevy_renet/examples/simple.rs
+++ b/bevy_renet/examples/simple.rs
@@ -53,10 +53,9 @@ fn new_renet_client() -> RenetClient {
 }
 
 fn new_renet_server() -> RenetServer {
-    let server_addr = "127.0.0.1:5000".parse().unwrap();
-    let socket = UdpSocket::bind(server_addr).unwrap();
+    let socket = UdpSocket::bind("127.0.0.1:5000").unwrap();
     let connection_config = RenetConnectionConfig::default();
-    let server_config = ServerConfig::new(64, PROTOCOL_ID, server_addr, *PRIVATE_KEY);
+    let server_config = ServerConfig::new(64, PROTOCOL_ID, *PRIVATE_KEY);
     let current_time = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap();
     RenetServer::new(current_time, server_config, connection_config, socket).unwrap()
 }

--- a/demo_chat/src/server.rs
+++ b/demo_chat/src/server.rs
@@ -24,7 +24,7 @@ impl ChatServer {
             channels_config: channels_config(),
             ..Default::default()
         };
-        let server_config = ServerConfig::new(64, 0, addr, *private_key);
+        let server_config = ServerConfig::new(64, 0, *private_key);
         let current_time = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap();
         let server = RenetServer::new(current_time, server_config, connection_config, socket).unwrap();
         let mut usernames = HashMap::new();

--- a/renet/examples/echo.rs
+++ b/renet/examples/echo.rs
@@ -65,7 +65,7 @@ const PROTOCOL_ID: u64 = 7;
 fn server(addr: SocketAddr) {
     let socket = UdpSocket::bind(addr).unwrap();
     let connection_config = RenetConnectionConfig::default();
-    let server_config = ServerConfig::new(64, PROTOCOL_ID, addr, *PRIVATE_KEY);
+    let server_config = ServerConfig::new(64, PROTOCOL_ID, *PRIVATE_KEY);
     let current_time = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap();
     let mut server: RenetServer = RenetServer::new(current_time, server_config, connection_config, socket).unwrap();
 

--- a/renet/src/server.rs
+++ b/renet/src/server.rs
@@ -37,19 +37,15 @@ pub struct ServerConfig {
     /// One could use a hash function with the game current version to generate this value.
     /// So old version would be unable to connect to newer versions.
     pub protocol_id: u64,
-    /// Publicly available address that clients will try to connect to. This is
-    /// the address used to generate the ConnectToken.
-    pub public_addr: SocketAddr,
     /// Private key used for encryption in the server
     pub private_key: [u8; NETCODE_KEY_BYTES],
 }
 
 impl ServerConfig {
-    pub fn new(max_clients: usize, protocol_id: u64, public_addr: SocketAddr, private_key: [u8; NETCODE_KEY_BYTES]) -> Self {
+    pub fn new(max_clients: usize, protocol_id: u64, private_key: [u8; NETCODE_KEY_BYTES]) -> Self {
         Self {
             max_clients,
             protocol_id,
-            public_addr,
             private_key,
         }
     }
@@ -68,7 +64,7 @@ impl RenetServer {
             current_time,
             server_config.max_clients,
             server_config.protocol_id,
-            server_config.public_addr,
+            socket.local_addr()?,
             server_config.private_key,
         );
 


### PR DESCRIPTION
I believe this will make server creation less error-prone.
It also makes it easier to use `0` for port to let the system pick one, since `local_addr()` returns the actual port used.