### PR TITLE
Rechannel: split channels into Sender/Receiver channels

### DIFF
--- a/demo_chat/src/client.rs
+++ b/demo_chat/src/client.rs
@@ -366,7 +366,8 @@ fn create_renet_client(username: String, server_addr: SocketAddr, private_key: &
     let client_addr = SocketAddr::from(([127, 0, 0, 1], 0));
     let socket = UdpSocket::bind(client_addr).unwrap();
     let connection_config = RenetConnectionConfig {
-        channels_config: channels_config(),
+        send_channels_config: channels_config(),
+        receive_channels_config: channels_config(),
         ..Default::default()
     };
 

--- a/demo_chat/src/server.rs
+++ b/demo_chat/src/server.rs
@@ -23,7 +23,8 @@ impl ChatServer {
     pub fn new(addr: SocketAddr, private_key: &[u8; NETCODE_KEY_BYTES], host_username: String) -> Self {
         let socket = UdpSocket::bind(addr).unwrap();
         let connection_config = RenetConnectionConfig {
-            channels_config: channels_config(),
+            send_channels_config: channels_config(),
+            receive_channels_config: channels_config(),
             ..Default::default()
         };
         let server_config = ServerConfig::new(64, 0, addr, *private_key);

--- a/rechannel/src/channel/reliable.rs
+++ b/rechannel/src/channel/reliable.rs
@@ -308,7 +308,7 @@ impl ReceiveChannel for ReceiveReliableChannel {
 
                     let max_message_id = self.received_message_id + self.messages_received.size() as u16 - 1;
                     if sequence_greater_than(message.id, max_message_id) {
-                        // Out of messages to add
+                        // Out of space to to add messages
                         self.error = Some(ChannelError::ReliableChannelOutOfSync);
                     }
 
@@ -317,7 +317,7 @@ impl ReceiveChannel for ReceiveReliableChannel {
                     }
                 }
                 Err(e) => {
-                    log::error!("Failed to deserialize reliable message {}: {}", self.channel_id, e);
+                    log::error!("Failed to deserialize reliable message in channel {}: {}", self.channel_id, e);
                     self.error = Some(ChannelError::FailedToSerialize);
                     return;
                 }

--- a/rechannel/src/channel/reliable.rs
+++ b/rechannel/src/channel/reliable.rs
@@ -464,7 +464,7 @@ mod tests {
         send_channel.send_message(message.clone());
         let second_channel_data = send_channel.get_messages_to_send(u64::MAX, 0).unwrap();
 
-        send_channel.send_message(message.clone());
+        send_channel.send_message(message);
         assert!(matches!(send_channel.error(), Some(ChannelError::ReliableChannelOutOfSync)));
 
         receive_channel.process_messages(first_channel_data.messages);

--- a/rechannel/src/channel/unreliable.rs
+++ b/rechannel/src/channel/unreliable.rs
@@ -1,5 +1,4 @@
 use crate::{
-    channel::Channel,
     error::ChannelError,
     packet::{ChannelPacketData, Payload},
 };
@@ -8,7 +7,7 @@ use std::{collections::VecDeque, time::Duration};
 
 use bytes::Bytes;
 
-use super::ChannelNetworkInfo;
+use super::{ReceiveChannel, SendChannel};
 
 /// Configuration for a unreliable and unordered channel.
 /// Messages sent in this channel will behave like a udp packet,
@@ -29,11 +28,21 @@ pub struct UnreliableChannelConfig {
 }
 
 #[derive(Debug)]
-pub(crate) struct UnreliableChannel {
-    config: UnreliableChannelConfig,
+pub(crate) struct SendUnreliableChannel {
+    channel_id: u8,
+    packet_budget: u64,
+    max_message_size: u64,
+    message_send_queue_size: usize,
     messages_to_send: VecDeque<Bytes>,
+    error: Option<ChannelError>,
+}
+
+#[derive(Debug)]
+pub(crate) struct ReceiveUnreliableChannel {
+    channel_id: u8,
+    max_message_size: u64,
+    message_receive_queue_size: usize,
     messages_received: VecDeque<Payload>,
-    info: ChannelNetworkInfo,
     error: Option<ChannelError>,
 }
 
@@ -49,29 +58,29 @@ impl Default for UnreliableChannelConfig {
     }
 }
 
-impl UnreliableChannel {
+impl SendUnreliableChannel {
     pub fn new(config: UnreliableChannelConfig) -> Self {
-        assert!(config.max_message_size < config.packet_budget);
+        assert!(config.max_message_size <= config.packet_budget);
 
         Self {
+            channel_id: config.channel_id,
+            packet_budget: config.packet_budget,
+            max_message_size: config.max_message_size,
+            message_send_queue_size: config.message_send_queue_size,
             messages_to_send: VecDeque::with_capacity(config.message_send_queue_size),
-            messages_received: VecDeque::with_capacity(config.message_receive_queue_size),
-            config,
-            info: ChannelNetworkInfo::default(),
             error: None,
         }
     }
 }
 
-impl Channel for UnreliableChannel {
+impl SendChannel for SendUnreliableChannel {
     fn get_messages_to_send(&mut self, mut available_bytes: u64, _sequence: u16) -> Option<ChannelPacketData> {
         if self.error.is_some() {
             return None;
         }
 
         let mut messages = vec![];
-
-        available_bytes = available_bytes.min(self.config.packet_budget);
+        available_bytes = available_bytes.min(self.packet_budget);
 
         while let Some(message) = self.messages_to_send.pop_front() {
             let message_size = message.len() as u64;
@@ -80,8 +89,6 @@ impl Channel for UnreliableChannel {
             }
 
             available_bytes -= message_size;
-            self.info.messages_sent += 1;
-            self.info.bytes_sent += message_size;
             messages.push(message.to_vec());
         }
 
@@ -90,80 +97,94 @@ impl Channel for UnreliableChannel {
         }
 
         Some(ChannelPacketData {
-            channel_id: self.config.channel_id,
+            channel_id: self.channel_id,
             messages,
         })
     }
 
-    fn advance_time(&mut self, _duration: Duration) {
-        self.info.reset();
-    }
-
-    fn process_messages(&mut self, mut messages: Vec<Payload>) {
-        if self.error.is_some() {
-            return;
-        }
-
-        while let Some(message) = messages.pop() {
-            if message.len() as u64 > self.config.max_message_size {
-                log::error!(
-                    "Received unreliable message with size above the limit, got {} bytes, expected less than {}",
-                    message.len(),
-                    self.config.max_message_size
-                );
-                self.error = Some(ChannelError::ReceivedMessageAboveMaxSize);
-                return;
-            }
-            if self.messages_received.len() == self.config.message_receive_queue_size {
-                log::warn!(
-                    "Received message was dropped in unreliable channel {}, reached maximum number of messages {}",
-                    self.config.channel_id,
-                    self.config.message_receive_queue_size
-                );
-                return;
-            }
-            self.info.messages_received += 1;
-            self.info.bytes_received += message.len() as u64;
-            self.messages_received.push_back(message);
-        }
-    }
-
     fn process_ack(&mut self, _ack: u16) {}
+
+    fn advance_time(&mut self, _duration: Duration) {}
 
     fn send_message(&mut self, payload: Bytes) {
         if self.error.is_some() {
             return;
         }
 
-        if payload.len() as u64 > self.config.max_message_size {
+        if payload.len() as u64 > self.max_message_size {
             log::error!(
                 "Tried to send unreliable message with size above the limit, got {} bytes, expected less than {}",
                 payload.len(),
-                self.config.max_message_size
+                self.max_message_size
             );
             self.error = Some(ChannelError::SentMessageAboveMaxSize);
             return;
         }
 
-        if self.messages_to_send.len() >= self.config.message_send_queue_size {
+        if self.messages_to_send.len() >= self.message_send_queue_size {
             self.error = Some(ChannelError::SendQueueFull);
-            log::warn!("Unreliable channel {} has reached the maximum queue size", self.config.channel_id);
+            log::warn!("Unreliable channel {} has reached the maximum queue size", self.channel_id);
             return;
         }
 
         self.messages_to_send.push_back(payload);
     }
 
+    fn can_send_message(&self) -> bool {
+        self.messages_to_send.len() < self.message_send_queue_size
+    }
+
+    fn error(&self) -> Option<ChannelError> {
+        self.error
+    }
+}
+
+impl ReceiveUnreliableChannel {
+    pub fn new(config: UnreliableChannelConfig) -> Self {
+        assert!(config.max_message_size <= config.packet_budget);
+
+        Self {
+            channel_id: config.channel_id,
+            max_message_size: config.max_message_size,
+            message_receive_queue_size: config.message_receive_queue_size,
+            messages_received: VecDeque::with_capacity(config.message_receive_queue_size),
+            error: None,
+        }
+    }
+}
+
+impl ReceiveChannel for ReceiveUnreliableChannel {
+    fn process_messages(&mut self, mut messages: Vec<Payload>) {
+        if self.error.is_some() {
+            return;
+        }
+
+        while let Some(message) = messages.pop() {
+            if message.len() as u64 > self.max_message_size {
+                log::error!(
+                    "Received unreliable message with size above the limit, got {} bytes, expected less than {}",
+                    message.len(),
+                    self.max_message_size
+                );
+                self.error = Some(ChannelError::ReceivedMessageAboveMaxSize);
+                return;
+            }
+
+            if self.messages_received.len() == self.message_receive_queue_size {
+                log::warn!(
+                    "Received message was dropped in unreliable channel {}, reached maximum number of messages {}",
+                    self.channel_id,
+                    self.message_receive_queue_size
+                );
+                return;
+            }
+
+            self.messages_received.push_back(message);
+        }
+    }
+
     fn receive_message(&mut self) -> Option<Payload> {
         self.messages_received.pop_front()
-    }
-
-    fn can_send_message(&self) -> bool {
-        self.messages_to_send.len() < self.config.message_send_queue_size
-    }
-
-    fn channel_network_info(&self) -> ChannelNetworkInfo {
-        self.info
     }
 
     fn error(&self) -> Option<ChannelError> {

--- a/rechannel/src/error.rs
+++ b/rechannel/src/error.rs
@@ -13,8 +13,10 @@ pub enum DisconnectionReason {
     DisconnectedByClient,
     /// Channel with given Id was not found
     InvalidChannelId(u8),
-    /// Error occurred in a channel
-    ChannelError { channel_id: u8, error: ChannelError },
+    /// Error occurred in a send channel
+    SendChannelError { channel_id: u8, error: ChannelError },
+    /// Error occurred in a receive channel
+    ReceiveChannelError { channel_id: u8, error: ChannelError },
 }
 
 /// Possibles errors that can occur in a channel.
@@ -25,6 +27,7 @@ pub enum ChannelError {
     /// The channel send queue has reach it's maximum
     SendQueueFull,
     /// Error occurred during (de)serialization
+    // TODO: rename to SerializationFailure
     FailedToSerialize,
     /// Tried to send a message that is above the channel max message size.
     SentMessageAboveMaxSize,
@@ -57,7 +60,8 @@ impl fmt::Display for DisconnectionReason {
             DisconnectedByServer => write!(fmt, "connection terminated by server"),
             DisconnectedByClient => write!(fmt, "connection terminated by client"),
             InvalidChannelId(id) => write!(fmt, "received message with invalid channel {}", id),
-            ChannelError { channel_id, error } => write!(fmt, "channel {} with error: {}", channel_id, error),
+            SendChannelError { channel_id, error } => write!(fmt, "send channel {} with error: {}", channel_id, error),
+            ReceiveChannelError { channel_id, error } => write!(fmt, "receive channel {} with error: {}", channel_id, error),
         }
     }
 }

--- a/rechannel/src/remote_connection.rs
+++ b/rechannel/src/remote_connection.rs
@@ -99,7 +99,7 @@ impl RemoteConnection {
         }
 
         let mut receive_channels = HashMap::new();
-        for channel_config in config.send_channels_config.iter() {
+        for channel_config in config.receive_channels_config.iter() {
             let (_, receive_channel) = channel_config.new_channels();
             let channel_id = channel_config.channel_id();
             let old_channel = receive_channels.insert(channel_id, receive_channel);

--- a/rechannel/src/sequence_buffer.rs
+++ b/rechannel/src/sequence_buffer.rs
@@ -9,11 +9,17 @@ pub(crate) struct SequenceBuffer<T> {
 
 impl<T: Clone> SequenceBuffer<T> {
     pub fn with_capacity(size: usize) -> Self {
+        assert!(size > 0, "tried to initialize SequenceBuffer with 0 size");
+
         Self {
             sequence: 0,
             entry_sequences: vec![None; size].into_boxed_slice(),
             entries: vec![None; size].into_boxed_slice(),
         }
+    }
+
+    pub fn size(&self) -> usize {
+        self.entries.len()
     }
 
     pub fn get_mut(&mut self, sequence: u16) -> Option<&mut T> {
@@ -130,12 +136,12 @@ impl<T: Clone> SequenceBuffer<T> {
 // Since sequences can wrap we need to check when this when checking greater
 // Ocurring the cutover in the middle of u16
 #[inline]
-fn sequence_greater_than(s1: u16, s2: u16) -> bool {
+pub fn sequence_greater_than(s1: u16, s2: u16) -> bool {
     ((s1 > s2) && (s1 - s2 <= 32768)) || ((s1 < s2) && (s2 - s1 > 32768))
 }
 
 #[inline]
-fn sequence_less_than(s1: u16, s2: u16) -> bool {
+pub fn sequence_less_than(s1: u16, s2: u16) -> bool {
     sequence_greater_than(s2, s1)
 }
 

--- a/rechannel/src/server.rs
+++ b/rechannel/src/server.rs
@@ -1,4 +1,3 @@
-use crate::channel::ChannelNetworkInfo;
 use crate::error::{DisconnectionReason, RechannelError};
 use crate::packet::Payload;
 use crate::remote_connection::{ConnectionConfig, RemoteConnection};
@@ -57,13 +56,6 @@ impl<C: ClientId> RechannelServer<C> {
         match self.connections.get(&connection_id) {
             Some(connection) => connection.packet_loss(),
             None => 0.0,
-        }
-    }
-
-    pub fn channels_network_info(&self, connection_id: C) -> Vec<(u8, ChannelNetworkInfo)> {
-        match self.connections.get(&connection_id) {
-            Some(connection) => connection.channels_network_info(),
-            None => Vec::with_capacity(0),
         }
     }
 

--- a/renet/src/client.rs
+++ b/renet/src/client.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 use log::debug;
-use rechannel::{channel::ChannelNetworkInfo, error::RechannelError, remote_connection::RemoteConnection, Bytes};
+use rechannel::{error::RechannelError, remote_connection::RemoteConnection, Bytes};
 use renetcode::{ConnectToken, NetcodeClient, NetcodeError, NETCODE_KEY_BYTES, NETCODE_MAX_PACKET_BYTES};
 
 use std::net::UdpSocket;
@@ -113,10 +113,6 @@ impl RenetClient {
             rtt: self.reliable_connection.rtt(),
             packet_loss: self.reliable_connection.packet_loss(),
         }
-    }
-
-    pub fn channels_network_info(&self) -> Vec<(u8, ChannelNetworkInfo)> {
-        self.reliable_connection.channels_network_info()
     }
 
     /// Send packets to the server.

--- a/renet/src/config.rs
+++ b/renet/src/config.rs
@@ -24,12 +24,20 @@ pub struct RenetConnectionConfig {
     pub bandwidth_smoothing_factor: f32,
     /// Value which specifies at which interval a heartbeat should be sent, if no other packet was sent in the meantime.
     pub heartbeat_time: Duration,
-    /// Per-channel configuration.
-    pub channels_config: Vec<ChannelConfig>,
+    /// Channels configuration that this client/server will use to send messages.
+    pub send_channels_config: Vec<ChannelConfig>,
+    /// Channels configuration that this client/server will use to receive messages.
+    pub receive_channels_config: Vec<ChannelConfig>,
 }
 
 impl Default for RenetConnectionConfig {
     fn default() -> Self {
+        let channels_config = vec![
+            ChannelConfig::Reliable(Default::default()),
+            ChannelConfig::Unreliable(Default::default()),
+            ChannelConfig::Block(Default::default()),
+        ];
+
         Self {
             max_packet_size: 16 * 1024,
             sent_packets_buffer_size: 256,
@@ -39,11 +47,8 @@ impl Default for RenetConnectionConfig {
             packet_loss_smoothing_factor: 0.1,
             bandwidth_smoothing_factor: 0.1,
             heartbeat_time: Duration::from_millis(100),
-            channels_config: vec![
-                ChannelConfig::Reliable(Default::default()),
-                ChannelConfig::Unreliable(Default::default()),
-                ChannelConfig::Block(Default::default()),
-            ],
+            send_channels_config: channels_config.clone(),
+            receive_channels_config: channels_config,
         }
     }
 }
@@ -63,7 +68,8 @@ impl RenetConnectionConfig {
             rtt_smoothing_factor: self.rtt_smoothing_factor,
             packet_loss_smoothing_factor: self.packet_loss_smoothing_factor,
             heartbeat_time: self.heartbeat_time,
-            channels_config: self.channels_config.clone(),
+            send_channels_config: self.send_channels_config.clone(),
+            receive_channels_config: self.receive_channels_config.clone(),
             fragment_config,
         }
     }

--- a/renet/src/lib.rs
+++ b/renet/src/lib.rs
@@ -5,7 +5,7 @@ mod error;
 mod network_info;
 mod server;
 
-pub use rechannel::channel::{BlockChannelConfig, ChannelConfig, ChannelNetworkInfo, ReliableChannelConfig, UnreliableChannelConfig};
+pub use rechannel::channel::{BlockChannelConfig, ChannelConfig, ReliableChannelConfig, UnreliableChannelConfig};
 pub use rechannel::error::{ChannelError, DisconnectionReason, RechannelError};
 
 pub use renetcode::{ConnectToken, NetcodeError};

--- a/renet/src/server.rs
+++ b/renet/src/server.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use log::error;
-use rechannel::{channel::ChannelNetworkInfo, disconnect_packet, error::DisconnectionReason, server::RechannelServer};
+use rechannel::{disconnect_packet, error::DisconnectionReason, server::RechannelServer};
 use renetcode::{NetcodeServer, ServerResult, NETCODE_KEY_BYTES, NETCODE_USER_DATA_BYTES};
 
 /// A server that can establish authenticated connections with multiple clients.
@@ -128,10 +128,6 @@ impl RenetServer {
         for client_id in self.netcode_server.clients_id() {
             self.disconnect(client_id);
         }
-    }
-
-    pub fn channels_network_info(&self, client_id: u64) -> Vec<(u8, ChannelNetworkInfo)> {
-        self.reliable_server.channels_network_info(client_id)
     }
 
     /// Returns the client's network info if the client exits.


### PR DESCRIPTION
These changes make it possible for the server and the client to have different channels. As an example, the client can now receive messages from 3 unreliable channels and send messages to 2 reliable channels, before the server and the client would need to have all equal channels and with the same configuration (with 3 unreliable channels and 2 reliables) . Now you can have different configurations for the channels you send and channels you receive from.

The configuration stays the same, internally when you create a channel it creates a sender and a receiver channel, but you need to pass 2 channel configurations, one for the senders and one for the receivers.



These changes came from the bad usability when trying to implement the bevy demo, I had channels that the server didn't use and the same thing for the client. Now it server/client has the exactly channels they use and you can give more meaningful names for the channels if you use an enum.

You can check the usuability change for the demo in this commit 6604e20759e7fe0be94fc85420ab5be0aeb4bf30

Before, channels didn't have meaningful names and some were unused:
```rust
pub enum Channel {
    Reliable,
    ReliableCritical,
    Unreliable,
}

pub fn channels_config() -> Vec<ChannelConfig> {
    vec![
        ReliableChannelConfig {
            channel_id: Channel::Reliable.id(),
            message_resend_time: Duration::from_millis(200),
            ..Default::default()
        }
        .into(),
        ReliableChannelConfig {
            channel_id: Channel::ReliableCritical.id(),
            message_resend_time: Duration::ZERO,
            ..Default::default()
        }
        .into(),
        UnreliableChannelConfig {
            channel_id: Channel::Unreliable.id(),
            ..Default::default()
        }
        .into(),
    ]
}
```

Now, you can give more explicit names for the channels and make sure no channel is unused and have different configuration for sending and receiving messages:
```rust
pub enum ClientChannel {
    Input,
    Command,
}

pub enum ServerChannel {
    ServerMessages,
    NetworkFrame,
}

impl ClientChannel {
    pub fn channels_config() -> Vec<ChannelConfig> {
        vec![
            ReliableChannelConfig {
                channel_id: Self::Input.id(),
                message_resend_time: Duration::ZERO,
                ..Default::default()
            }
            .into(),
            ReliableChannelConfig {
                channel_id: Self::Command.id(),
                message_resend_time: Duration::ZERO,
                ..Default::default()
            }
            .into(),
        ]
    }
}

impl ServerChannel {
    pub fn channels_config() -> Vec<ChannelConfig> {
        vec![
            UnreliableChannelConfig {
                channel_id: Self::NetworkFrame.id(),
                ..Default::default()
            }
            .into(),
            ReliableChannelConfig {
                channel_id: Self::ServerMessages.id(),
                message_resend_time: Duration::from_millis(200),
                ..Default::default()
            }
            .into(),
        ]
    }
}
```