### PR TITLE
Distinguish between kilobyte and kilobit, some nicer defaults for graphs

### DIFF
--- a/renet/src/network_info.rs
+++ b/renet/src/network_info.rs
@@ -59,7 +59,7 @@ impl<const N: usize> CircularBuffer<N, PacketInfo> {
         }
 
         let milli_seconds = (end - start).as_secs_f32() * 1000.0;
-        (bytes_sent * 8) as f32 / milli_seconds
+        bytes_sent as f32 / milli_seconds
     }
 }
 

--- a/renet/src/network_info.rs
+++ b/renet/src/network_info.rs
@@ -9,9 +9,9 @@ const CIRCULAR_BUFFER_SIZE: usize = 60;
 pub struct NetworkInfo {
     /// Round-trip Time
     pub rtt: f32,
-    /// Sent kilobytes per second.
+    /// Sent kilobits per second.
     pub sent_kbps: f32,
-    /// Received kilobytes per second.
+    /// Received kilobits per second.
     pub received_kbps: f32,
     pub packet_loss: f32,
 }
@@ -33,14 +33,14 @@ pub struct ClientPacketInfo {
     packets_sent: CircularBuffer<CIRCULAR_BUFFER_SIZE, PacketInfo>,
     packets_received: CircularBuffer<CIRCULAR_BUFFER_SIZE, PacketInfo>,
     bandwidth_smoothing_factor: f32,
-    /// Sent kilobytes per second.
+    /// Sent kilobits per second.
     pub sent_kbps: f32,
-    /// Received kilobytes per second.
+    /// Received kilobits per second.
     pub received_kbps: f32,
 }
 
 impl<const N: usize> CircularBuffer<N, PacketInfo> {
-    pub fn kilobytes_per_secs(&self) -> f32 {
+    pub fn kilobits_per_second(&self) -> f32 {
         let mut start = Duration::MAX;
         let mut end = Duration::ZERO;
         let mut bytes_sent = 0;
@@ -63,7 +63,7 @@ impl<const N: usize> CircularBuffer<N, PacketInfo> {
         }
 
         let milli_seconds = (end - start).as_secs_f32() * 1000.0;
-        bytes_sent as f32 / milli_seconds
+        (bytes_sent * 8) as f32 / milli_seconds
     }
 }
 
@@ -87,14 +87,14 @@ impl ClientPacketInfo {
     }
 
     pub fn update_metrics(&mut self) {
-        let sent_kbps = self.packets_sent.kilobytes_per_secs();
+        let sent_kbps = self.packets_sent.kilobits_per_second();
         if self.sent_kbps == 0.0 || self.sent_kbps < f32::EPSILON {
             self.sent_kbps = sent_kbps;
         } else {
             self.sent_kbps += (sent_kbps - self.sent_kbps) * self.bandwidth_smoothing_factor;
         }
 
-        let received_kbps = self.packets_received.kilobytes_per_secs();
+        let received_kbps = self.packets_received.kilobits_per_second();
         if self.received_kbps == 0.0 || self.received_kbps < f32::EPSILON {
             self.received_kbps = received_kbps;
         } else {

--- a/renet/src/network_info.rs
+++ b/renet/src/network_info.rs
@@ -9,7 +9,9 @@ const CIRCULAR_BUFFER_SIZE: usize = 60;
 pub struct NetworkInfo {
     /// Round-trip Time
     pub rtt: f32,
+    /// Sent kilobytes per second.
     pub sent_kbps: f32,
+    /// Received kilobytes per second.
     pub received_kbps: f32,
     pub packet_loss: f32,
 }
@@ -31,7 +33,9 @@ pub struct ClientPacketInfo {
     packets_sent: CircularBuffer<CIRCULAR_BUFFER_SIZE, PacketInfo>,
     packets_received: CircularBuffer<CIRCULAR_BUFFER_SIZE, PacketInfo>,
     bandwidth_smoothing_factor: f32,
+    /// Sent kilobytes per second.
     pub sent_kbps: f32,
+    /// Received kilobytes per second.
     pub received_kbps: f32,
 }
 

--- a/renet_visualizer/src/lib.rs
+++ b/renet_visualizer/src/lib.rs
@@ -125,7 +125,7 @@ impl<const N: usize> RenetClientVisualizer<N> {
             &self.style,
             "Received Kbps",
             TextFormat::Normal,
-            TopValue::MaxValue { multiplicated: 1.0 },
+            TopValue::MaxValue { multiplicated: 1.5 },
             self.received_bandwidth_kbps.as_vec(),
         );
     }
@@ -137,7 +137,7 @@ impl<const N: usize> RenetClientVisualizer<N> {
             &self.style,
             "Sent Kbps",
             TextFormat::Normal,
-            TopValue::MaxValue { multiplicated: 1.0 },
+            TopValue::MaxValue { multiplicated: 1.5 },
             self.sent_bandwidth_kbps.as_vec(),
         );
     }

--- a/renet_visualizer/src/lib.rs
+++ b/renet_visualizer/src/lib.rs
@@ -7,7 +7,7 @@ use egui::{
 use renet::{CircularBuffer, NetworkInfo, RenetServer};
 
 /// Egui visualizer for the renet client. Draws graphs with metrics:
-/// RTT, Packet Loss, Kilobytes Per Second Sent/Received.
+/// RTT, Packet Loss, Kbitps Sent/Received.
 ///
 /// N: determines how many values are shown in the graph.
 /// 200 is a good value, if updated at 60 fps the graphs would hold 3 seconds of data.
@@ -20,7 +20,7 @@ pub struct RenetClientVisualizer<const N: usize> {
 }
 
 /// Egui visualizer for the renet server. Draws graphs for each connected client with metrics:
-/// RTT, Packet Loss, Kilobytes Per Second Sent/Received.
+/// RTT, Packet Loss, Kbitps Sent/Received.
 ///
 /// N: determines how many values are shown in the graph.
 /// 200 is a good value, if updated at 60 fps the graphs would hold 3 seconds of data.
@@ -118,24 +118,24 @@ impl<const N: usize> RenetClientVisualizer<N> {
             });
     }
 
-    /// Draws only the Received Kilobytes Per Second metric.
+    /// Draws only the Received Kilobits Per Second metric.
     pub fn draw_received_kbps(&self, ui: &mut egui::Ui) {
         show_graph(
             ui,
             &self.style,
-            "Received Kilobytes Per Second",
+            "Received Kbitps",
             TextFormat::Normal,
             TopValue::MaxValue { multiplicated: 1.5 },
             self.received_bandwidth_kbps.as_vec(),
         );
     }
 
-    /// Draws only the Sent Kilobytes Per Second metric.
+    /// Draws only the Sent Kilobits Per Second metric.
     pub fn draw_sent_kbps(&self, ui: &mut egui::Ui) {
         show_graph(
             ui,
             &self.style,
-            "Sent Kilobytes Per Second",
+            "Sent Kbitps",
             TextFormat::Normal,
             TopValue::MaxValue { multiplicated: 1.5 },
             self.sent_bandwidth_kbps.as_vec(),

--- a/renet_visualizer/src/lib.rs
+++ b/renet_visualizer/src/lib.rs
@@ -7,7 +7,7 @@ use egui::{
 use renet::{CircularBuffer, NetworkInfo, RenetServer};
 
 /// Egui visualizer for the renet client. Draws graphs with metrics:
-/// RTT, Packet Loss, Kbps Sent/Received.
+/// RTT, Packet Loss, Kilobytes Per Second Sent/Received.
 ///
 /// N: determines how many values are shown in the graph.
 /// 200 is a good value, if updated at 60 fps the graphs would hold 3 seconds of data.
@@ -20,7 +20,7 @@ pub struct RenetClientVisualizer<const N: usize> {
 }
 
 /// Egui visualizer for the renet server. Draws graphs for each connected client with metrics:
-/// RTT, Packet Loss, Kbps Sent/Received.
+/// RTT, Packet Loss, Kilobytes Per Second Sent/Received.
 ///
 /// N: determines how many values are shown in the graph.
 /// 200 is a good value, if updated at 60 fps the graphs would hold 3 seconds of data.
@@ -118,24 +118,24 @@ impl<const N: usize> RenetClientVisualizer<N> {
             });
     }
 
-    /// Draws only the Received Kbps metric.
+    /// Draws only the Received Kilobytes Per Second metric.
     pub fn draw_received_kbps(&self, ui: &mut egui::Ui) {
         show_graph(
             ui,
             &self.style,
-            "Received Kbps",
+            "Received Kilobytes Per Second",
             TextFormat::Normal,
             TopValue::MaxValue { multiplicated: 1.5 },
             self.received_bandwidth_kbps.as_vec(),
         );
     }
 
-    /// Draws only the Sent Kbps metric.
+    /// Draws only the Sent Kilobytes Per Second metric.
     pub fn draw_sent_kbps(&self, ui: &mut egui::Ui) {
         show_graph(
             ui,
             &self.style,
-            "Sent Kbps",
+            "Sent Kilobytes Per Second",
             TextFormat::Normal,
             TopValue::MaxValue { multiplicated: 1.5 },
             self.sent_bandwidth_kbps.as_vec(),


### PR DESCRIPTION
Might be a good idea to distinguish between it in the visualizer instead of just `Kbps` since kilobits are commonly used in networking speedtest stuff, but kilobytes are just generally commonly used.

Can change this to whichever we want, I just think it'd be nice to have an explicit "Kilobytes per second" or "Kilobits per second"header.