### PR TITLE
Genericify send/recv methods

### DIFF
--- a/rechannel/src/remote_connection.rs
+++ b/rechannel/src/remote_connection.rs
@@ -153,17 +153,17 @@ impl RemoteConnection {
         };
     }
 
-    pub fn can_send_message(&self, channel_id: u8) -> bool {
+    pub fn can_send_message<I: Into<u8>>(&self, channel_id: I) -> bool {
         let channel = self.send_channels.get(&channel_id).expect("invalid channel id");
         channel.can_send_message()
     }
 
-    pub fn send_message(&mut self, channel_id: u8, message: Bytes) {
-        let channel = self.send_channels.get_mut(&channel_id).expect("invalid channel id");
+    pub fn send_message<I: Into<u8>, B: Into<Bytes>>(&mut self, channel_id: I, message: B) {
+        let channel = self.send_channels.get_mut(&channel_id.into()).expect("invalid channel id");
         channel.send_message(message, self.current_time);
     }
 
-    pub fn receive_message(&mut self, channel_id: u8) -> Option<Payload> {
+    pub fn receive_message<I: Into<u8>>(&mut self, channel_id: I) -> Option<Payload> {
         let channel = self.receive_channels.get_mut(&channel_id).expect("invalid channel id");
         channel.receive_message()
     }

--- a/rechannel/src/remote_connection.rs
+++ b/rechannel/src/remote_connection.rs
@@ -154,17 +154,17 @@ impl RemoteConnection {
     }
 
     pub fn can_send_message<I: Into<u8>>(&self, channel_id: I) -> bool {
-        let channel = self.send_channels.get(&channel_id).expect("invalid channel id");
+        let channel = self.send_channels.get(&channel_id.into()).expect("invalid channel id");
         channel.can_send_message()
     }
 
     pub fn send_message<I: Into<u8>, B: Into<Bytes>>(&mut self, channel_id: I, message: B) {
         let channel = self.send_channels.get_mut(&channel_id.into()).expect("invalid channel id");
-        channel.send_message(message, self.current_time);
+        channel.send_message(message.into(), self.current_time);
     }
 
     pub fn receive_message<I: Into<u8>>(&mut self, channel_id: I) -> Option<Payload> {
-        let channel = self.receive_channels.get_mut(&channel_id).expect("invalid channel id");
+        let channel = self.receive_channels.get_mut(&channel_id.into()).expect("invalid channel id");
         channel.receive_message()
     }
 
@@ -427,7 +427,7 @@ mod tests {
         let config = ConnectionConfig::default();
         let mut connection = RemoteConnection::new(Duration::ZERO, config);
         let message = vec![7u8; 2500];
-        connection.send_message(0, message.clone().into());
+        connection.send_message(0, message.clone());
 
         let packets = connection.get_packets_to_send().unwrap();
         assert!(packets.len() > 1);

--- a/rechannel/src/server.rs
+++ b/rechannel/src/server.rs
@@ -77,14 +77,16 @@ impl<C: ClientId> RechannelServer<C> {
         }
     }
 
-    pub fn broadcast_message<B: Into<Bytes>, I: Into<u8>>(&mut self, channel_id: I, message: B) {
+    pub fn broadcast_message<I: Into<u8>, B: Into<Bytes>>(&mut self, channel_id: I, message: B) {
+        let channel_id = channel_id.into();
         let message = message.into();
         for connection in self.connections.values_mut() {
             connection.send_message(channel_id, message.clone());
         }
     }
 
-    pub fn broadcast_message_except<B: Into<Bytes>, I: Into<u8>>(&mut self, except_id: &C, channel_id: I, message: B) {
+    pub fn broadcast_message_except<I: Into<u8>, B: Into<Bytes>>(&mut self, except_id: &C, channel_id: I, message: B) {
+        let channel_id = channel_id.into();
         let message = message.into();
         for (connection_id, connection) in self.connections.iter_mut() {
             if except_id == connection_id {
@@ -95,26 +97,23 @@ impl<C: ClientId> RechannelServer<C> {
         }
     }
 
-    pub fn can_send_message<I: Into<u8>>(&self, connection_id: &C, channel_id: C) -> bool {
-        let channel_id = channel_id.into();
+    pub fn can_send_message<I: Into<u8>>(&self, connection_id: &C, channel_id: I) -> bool {
         match self.connections.get(connection_id) {
             Some(connection) => connection.can_send_message(channel_id),
             None => false,
         }
     }
 
-    pub fn send_message<B: Into<Bytes>, I: Into<u8>>(&mut self, connection_id: &C, channel_id: I, message: B) {
-        let message = message.into();
-        let channel_id = channel_id.into();
+    pub fn send_message<I: Into<u8>, B: Into<Bytes>>(&mut self, connection_id: &C, channel_id: I, message: B) {
         match self.connections.get_mut(connection_id) {
             Some(connection) => connection.send_message(channel_id, message),
             None => log::error!("Tried to send message to disconnected client {:?}", connection_id),
         }
     }
 
-    pub fn receive_message<C: Into<u8>>(&mut self, connection_id: &C, channel_id: C) -> Option<Payload> {
+    pub fn receive_message<I: Into<u8>>(&mut self, connection_id: &C, channel_id: I) -> Option<Payload> {
         if let Some(connection) = self.connections.get_mut(connection_id) {
-            return connection.receive_message(channel_id.into());
+            return connection.receive_message(channel_id);
         }
         None
     }

--- a/rechannel/src/server.rs
+++ b/rechannel/src/server.rs
@@ -77,15 +77,15 @@ impl<C: ClientId> RechannelServer<C> {
         }
     }
 
-    pub fn broadcast_message(&mut self, channel_id: u8, message: Vec<u8>) {
-        let message = Bytes::from(message);
+    pub fn broadcast_message<B: Into<Bytes>, I: Into<u8>>(&mut self, channel_id: I, message: B) {
+        let message = message.into();
         for connection in self.connections.values_mut() {
             connection.send_message(channel_id, message.clone());
         }
     }
 
-    pub fn broadcast_message_except(&mut self, except_id: &C, channel_id: u8, message: Vec<u8>) {
-        let message = Bytes::from(message);
+    pub fn broadcast_message_except<B: Into<Bytes>, I: Into<u8>>(&mut self, except_id: &C, channel_id: I, message: B) {
+        let message = message.into();
         for (connection_id, connection) in self.connections.iter_mut() {
             if except_id == connection_id {
                 continue;
@@ -95,24 +95,26 @@ impl<C: ClientId> RechannelServer<C> {
         }
     }
 
-    pub fn can_send_message(&self, connection_id: &C, channel_id: u8) -> bool {
+    pub fn can_send_message<I: Into<u8>>(&self, connection_id: &C, channel_id: C) -> bool {
+        let channel_id = channel_id.into();
         match self.connections.get(connection_id) {
             Some(connection) => connection.can_send_message(channel_id),
             None => false,
         }
     }
 
-    pub fn send_message(&mut self, connection_id: &C, channel_id: u8, message: Vec<u8>) {
-        let message = Bytes::from(message);
+    pub fn send_message<B: Into<Bytes>, I: Into<u8>>(&mut self, connection_id: &C, channel_id: I, message: B) {
+        let message = message.into();
+        let channel_id = channel_id.into();
         match self.connections.get_mut(connection_id) {
             Some(connection) => connection.send_message(channel_id, message),
             None => log::error!("Tried to send message to disconnected client {:?}", connection_id),
         }
     }
 
-    pub fn receive_message(&mut self, connection_id: &C, channel_id: u8) -> Option<Payload> {
+    pub fn receive_message<C: Into<u8>>(&mut self, connection_id: &C, channel_id: C) -> Option<Payload> {
         if let Some(connection) = self.connections.get_mut(connection_id) {
-            return connection.receive_message(channel_id);
+            return connection.receive_message(channel_id.into());
         }
         None
     }

--- a/renet/src/client.rs
+++ b/renet/src/client.rs
@@ -91,18 +91,17 @@ impl RenetClient {
     }
 
     /// Receive a message from the server over a channel.
-    pub fn receive_message(&mut self, channel_id: u8) -> Option<Vec<u8>> {
+    pub fn receive_message<I: Into<u8>>(&mut self, channel_id: I) -> Option<Vec<u8>> {
         self.reliable_connection.receive_message(channel_id)
     }
 
     /// Send a message to the server over a channel.
-    pub fn send_message(&mut self, channel_id: u8, message: Vec<u8>) {
-        let message = Bytes::from(message);
+    pub fn send_message<I: Into<u8>, B: Into<Bytes>>(&mut self, channel_id: I, message: B) {
         self.reliable_connection.send_message(channel_id, message);
     }
 
     /// Verifies if a message can be sent to the server over a channel.
-    pub fn can_send_message(&self, channel_id: u8) -> bool {
+    pub fn can_send_message<I: Into<u8>>(&self, channel_id: I) -> bool {
         self.reliable_connection.can_send_message(channel_id)
     }
 

--- a/renet/src/server.rs
+++ b/renet/src/server.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use log::error;
-use rechannel::{disconnect_packet, error::DisconnectionReason, server::RechannelServer};
+use rechannel::{disconnect_packet, error::DisconnectionReason, server::RechannelServer, Bytes};
 use renetcode::{NetcodeServer, ServerResult, NETCODE_KEY_BYTES, NETCODE_USER_DATA_BYTES};
 
 /// A server that can establish authenticated connections with multiple clients.
@@ -223,27 +223,27 @@ impl RenetServer {
     }
 
     /// Receive a message from a client over a channel.
-    pub fn receive_message(&mut self, client_id: u64, channel_id: u8) -> Option<Vec<u8>> {
+    pub fn receive_message<I: Into<u8>>(&mut self, client_id: u64, channel_id: I) -> Option<Vec<u8>> {
         self.reliable_server.receive_message(&client_id, channel_id)
     }
 
     /// Verifies if a message can be sent to a client over a channel.
-    pub fn can_send_message(&self, client_id: u64, channel_id: u8) -> bool {
+    pub fn can_send_message<I: Into<u8>>(&self, client_id: u64, channel_id: I) -> bool {
         self.reliable_server.can_send_message(&client_id, channel_id)
     }
 
     /// Send a message to a client over a channel.
-    pub fn send_message(&mut self, client_id: u64, channel_id: u8, message: Vec<u8>) {
+    pub fn send_message<I: Into<u8>, B: Into<Bytes>>(&mut self, client_id: u64, channel_id: I, message: B) {
         self.reliable_server.send_message(&client_id, channel_id, message);
     }
 
     /// Send a message to all client, except the specified one, over a channel.
-    pub fn broadcast_message_except(&mut self, client_id: u64, channel_id: u8, message: Vec<u8>) {
+    pub fn broadcast_message_except<I: Into<u8>, B: Into<Bytes>>(&mut self, client_id: u64, channel_id: I, message: B) {
         self.reliable_server.broadcast_message_except(&client_id, channel_id, message)
     }
 
     /// Send a message to all client over a channel.
-    pub fn broadcast_message(&mut self, channel_id: u8, message: Vec<u8>) {
+    pub fn broadcast_message<I: Into<u8>, B: Into<Bytes>>(&mut self, channel_id: I, message: B) {
         self.reliable_server.broadcast_message(channel_id, message);
     }
 


### PR DESCRIPTION
Allows for more types to be passed in so users can decide more on how they want to store/pass in data.

Fixes #26 
