### PR TITLE
Update to Bevy 0.9

### DIFF
--- a/bevy_renet/Cargo.toml
+++ b/bevy_renet/Cargo.toml
@@ -11,10 +11,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.8.0", default-features = false }
-renet = { path = "../renet", version = "0.0.9" }
+bevy = { version = "0.9.0", default-features = false }
+renet = { path = "../renet", version = "0.0.9", features = ["bevy"] }
 
 [dev-dependencies]
 serde = { version = "1.0", features = [ "derive" ] } 
-bevy = { version = "0.8.0", default-features = false, features = ["bevy_core_pipeline", "bevy_render", "bevy_asset", "bevy_pbr", "x11"] }
+bevy = { version = "0.9.0", default-features = false, features = ["bevy_core_pipeline", "bevy_render", "bevy_asset", "bevy_pbr", "x11"] }
 bincode = "1.3.1"

--- a/renet/Cargo.toml
+++ b/renet/Cargo.toml
@@ -9,8 +9,11 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+bevy = ["dep:bevy_ecs"]
 
 [dependencies]
 rechannel = { path = "../rechannel", version = "0.0.5" }
 renetcode = { path = "../renetcode", version = "0.0.5" }
 log = "0.4.17"
+bevy_ecs = { version = "0.9.0", optional = true }

--- a/renet/src/client.rs
+++ b/renet/src/client.rs
@@ -32,6 +32,7 @@ pub enum ClientAuthentication {
 
 /// A client that establishes an authenticated connection with a server.
 /// Can send/receive encrypted messages from/to the server.
+#[cfg_attr(feature = "bevy", derive(bevy_ecs::system::Resource))]
 pub struct RenetClient {
     current_time: Duration,
     netcode_client: NetcodeClient,

--- a/renet/src/server.rs
+++ b/renet/src/server.rs
@@ -17,6 +17,7 @@ use renetcode::{NetcodeServer, ServerResult, NETCODE_KEY_BYTES, NETCODE_USER_DAT
 /// A server that can establish authenticated connections with multiple clients.
 /// Can send/receive encrypted messages from/to them.
 #[derive(Debug)]
+#[cfg_attr(feature = "bevy", derive(bevy_ecs::system::Resource))]
 pub struct RenetServer {
     socket: UdpSocket,
     reliable_server: RechannelServer<u64>,


### PR DESCRIPTION
Updates `bevy_renet` to Bevy 0.9

I've chosen the approach to introduce an optional feature to `renet`. This way there doesn't need to be a wrapper type and all usages can stay the same.

The changes have only be tested when using Bevy, as I've made the minimal changes required to make it work in my project. 