### PR TITLE
Bleeding Edge Bevy

### DIFF
--- a/.github/workflows/bevy_main.yml
+++ b/.github/workflows/bevy_main.yml
@@ -1,0 +1,26 @@
+name: check if code still compiles
+
+on:
+  schedule:
+    - cron: '0 8 * * *'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Dependencies
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends pkg-config libx11-dev libasound2-dev libudev-dev
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Check code
+        run: cargo update && cargo check --lib --examples

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["renet", "demo_chat", "demo_bevy", "renetcode", "bevy_renet", "renet_visualizer"]
+members = ["renet", "demo_chat", "renetcode", "bevy_renet", "renet_visualizer"]
 resolver = "2"

--- a/bevy_renet/Cargo.toml
+++ b/bevy_renet/Cargo.toml
@@ -15,11 +15,11 @@ default = ["transport"]
 transport = ["renet/transport"]
 
 [dependencies]
-bevy = {git = "https://github.com/bevyengine/bevy.git", default-features = false}
+bevy = {git = "https://github.com/bevyengine/bevy?rev=8ec8149", default-features = false}
 renet = {path = "../renet", version = "0.0.12", features = ["bevy"]}
 
 [dev-dependencies]
-bevy = {git = "https://github.com/bevyengine/bevy.git", default-features = false, features = ["bevy_core_pipeline", "bevy_render", "bevy_asset", "bevy_pbr", "x11", "ktx2", "tonemapping_luts", "zstd"]}
+bevy = {git = "https://github.com/bevyengine/bevy?rev=8ec8149", default-features = false, features = ["bevy_core_pipeline", "bevy_render", "bevy_asset", "bevy_pbr", "x11", "ktx2", "tonemapping_luts", "zstd"]}
 bincode = "1.3.1"
 env_logger = "0.10.0"
 serde = {version = "1.0", features = ["derive"]}

--- a/bevy_renet/Cargo.toml
+++ b/bevy_renet/Cargo.toml
@@ -19,7 +19,7 @@ bevy = {git = "https://github.com/bevyengine/bevy.git", default-features = false
 renet = {path = "../renet", version = "0.0.12", features = ["bevy"]}
 
 [dev-dependencies]
-bevy = {git = "https://github.com/bevyengine/bevy.git", default-features = false, features = ["bevy_core_pipeline", "bevy_render", "bevy_asset", "bevy_pbr", "x11"]}
+bevy = {git = "https://github.com/bevyengine/bevy.git", default-features = false, features = ["bevy_core_pipeline", "bevy_render", "bevy_asset", "bevy_pbr", "x11", "ktx2", "tonemapping_luts", "zstd"]}
 bincode = "1.3.1"
 env_logger = "0.10.0"
 serde = {version = "1.0", features = ["derive"]}

--- a/bevy_renet/Cargo.toml
+++ b/bevy_renet/Cargo.toml
@@ -15,11 +15,11 @@ default = ["transport"]
 transport = ["renet/transport"]
 
 [dependencies]
-bevy = {version = "0.10.1", default-features = false}
+bevy = {git = "https://github.com/bevyengine/bevy.git", default-features = false}
 renet = {path = "../renet", version = "0.0.12", features = ["bevy"]}
 
 [dev-dependencies]
-bevy = {version = "0.10.1", default-features = false, features = ["bevy_core_pipeline", "bevy_render", "bevy_asset", "bevy_pbr", "x11"]}
+bevy = {git = "https://github.com/bevyengine/bevy.git", default-features = false, features = ["bevy_core_pipeline", "bevy_render", "bevy_asset", "bevy_pbr", "x11"]}
 bincode = "1.3.1"
 env_logger = "0.10.0"
 serde = {version = "1.0", features = ["derive"]}

--- a/bevy_renet/Cargo.toml
+++ b/bevy_renet/Cargo.toml
@@ -15,11 +15,11 @@ default = ["transport"]
 transport = ["renet/transport"]
 
 [dependencies]
-bevy = {git = "https://github.com/bevyengine/bevy?rev=8ec8149", default-features = false}
+bevy = {git = "https://github.com/bevyengine/bevy?rev=84de9e7", default-features = false}
 renet = {path = "../renet", version = "0.0.12", features = ["bevy"]}
 
 [dev-dependencies]
-bevy = {git = "https://github.com/bevyengine/bevy?rev=8ec8149", default-features = false, features = ["bevy_core_pipeline", "bevy_render", "bevy_asset", "bevy_pbr", "x11", "ktx2", "tonemapping_luts", "zstd"]}
+bevy = {git = "https://github.com/bevyengine/bevy?rev=84de9e7", default-features = false, features = ["bevy_core_pipeline", "bevy_render", "bevy_asset", "bevy_pbr", "x11", "ktx2", "tonemapping_luts", "zstd"]}
 bincode = "1.3.1"
 env_logger = "0.10.0"
 serde = {version = "1.0", features = ["derive"]}

--- a/bevy_renet/README.md
+++ b/bevy_renet/README.md
@@ -124,3 +124,37 @@ If you want a more complex example you can checkout the [demo_bevy](https://gith
 |0.9|0.0.6|
 |0.8|0.0.5|
 |0.7|0.0.4|
+
+## The Bleeding Edge
+
+Read more about Bleeding Edge Bevy in the [Unofficial Bevy Cheat Book](https://bevy-cheatbook.github.io/setup/bevy-git.html). Please note: bleeding edge Bevy and by extension bleeding edge Renet is very unstable.
+
+There is more than one way to do this but I will be covering only one. The idea is to make your project depend on the exact same commit of Bevy that Renet depends on. This makes sure Renet and your project are on the same page and there aren't conflicting definitions. Manual updates are required but it means you can choose when to deal with breaking changes.
+
+Open `bevy_renet/Cargo.toml` on the `bleeding-edge` branch. Copy the `bevy` dependency into your project's `Cargo.toml`. It will look something like:
+```toml 
+bevy = {git = "https://github.com/bevyengine/bevy?rev=a420beb0"}
+```
+Notice it specifies an exact commit using `?rev=` followed by a commit hash. Now copy the latest commit hash in the `bleeding-edge` branch and add a dependency for `bevy_renet` in your project's Cargo.toml. It should look something like:
+```toml 
+bevy_renet = {git = "https://github.com/roanv/renet?rev=146123ea"}
+```
+
+You should end up with something like:
+
+```toml
+# YOUR_PROJECT/Cargo.toml
+[dependencies]
+bevy = {git = "https://github.com/bevyengine/bevy?rev=a420beb0"} # matching bevy/main commit
+bevy_renet = {git = "https://github.com/roanv/renet?rev=146123ea"} # latest bleeding-edge commit 
+```
+```toml
+# bevy_renet/Cargo.toml on bleeding-edge branch for latest commit #146123ea
+bevy = {git = "https://github.com/bevyengine/bevy?rev=a420beb0"} # matching bevy/main commit
+```
+
+To update, simply repeat the process with the latest commit in the `bleeding-edge` branch.
+
+#### bUt i WaNt tHe lAteSt bEvY!
+
+Have a look at the [Unofficial Bevy Cheat Book](https://bevy-cheatbook.github.io/setup/bevy-git.html). There is a way to patch bleeding-edge to depend on a more recent Bevy commit. This will only work if no breaking changes have been made to parts Renet uses.

--- a/bevy_renet/README.md
+++ b/bevy_renet/README.md
@@ -137,7 +137,7 @@ bevy = {git = "https://github.com/bevyengine/bevy?rev=a420beb0"}
 ```
 Notice it specifies an exact commit using `?rev=` followed by a commit hash. Now copy the latest commit hash in the `bleeding-edge` branch and add a dependency for `bevy_renet` in your project's Cargo.toml. It should look something like:
 ```toml 
-bevy_renet = {git = "https://github.com/roanv/renet?rev=146123ea"}
+bevy_renet = {git = "https://github.com/roanvonb/renet?rev=146123ea"}
 ```
 
 You should end up with something like:
@@ -146,7 +146,7 @@ You should end up with something like:
 # YOUR_PROJECT/Cargo.toml
 [dependencies]
 bevy = {git = "https://github.com/bevyengine/bevy?rev=a420beb0"} # matching bevy/main commit
-bevy_renet = {git = "https://github.com/roanv/renet?rev=146123ea"} # latest bleeding-edge commit 
+bevy_renet = {git = "https://github.com/roanvonb/renet?rev=146123ea"} # latest bleeding-edge commit 
 ```
 ```toml
 # bevy_renet/Cargo.toml on bleeding-edge branch for latest commit #146123ea

--- a/bevy_renet/examples/simple.rs
+++ b/bevy_renet/examples/simple.rs
@@ -101,7 +101,7 @@ fn main() {
         app.insert_resource(server);
         app.insert_resource(transport);
 
-        app.add_systems(Main, (server_update_system, server_sync_players, move_players_system));
+        app.add_systems(Update, (server_update_system, server_sync_players, move_players_system));
     } else {
         app.add_plugin(RenetClientPlugin);
         app.add_plugin(NetcodeClientPlugin);
@@ -111,13 +111,13 @@ fn main() {
         app.insert_resource(transport);
 
         app.add_systems(
-            Main,
+            Update,
             (player_input, client_send_input, client_sync_players).distributive_run_if(bevy_renet::transport::client_connected),
         );
     }
 
     app.add_systems(Startup, setup);
-    app.add_systems(Main, panic_on_error_system);
+    app.add_systems(Update, panic_on_error_system);
 
     app.run();
 }

--- a/bevy_renet/examples/simple.rs
+++ b/bevy_renet/examples/simple.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::{shape::Plane, *};
+use bevy::prelude::*;
 use bevy_renet::{
     renet::{
         transport::{ClientAuthentication, ServerAuthentication, ServerConfig},
@@ -101,7 +101,7 @@ fn main() {
         app.insert_resource(server);
         app.insert_resource(transport);
 
-        app.add_systems((server_update_system, server_sync_players, move_players_system));
+        app.add_systems(Main, (server_update_system, server_sync_players, move_players_system));
     } else {
         app.add_plugin(RenetClientPlugin);
         app.add_plugin(NetcodeClientPlugin);
@@ -111,14 +111,13 @@ fn main() {
         app.insert_resource(transport);
 
         app.add_systems(
-            (player_input, client_send_input, client_sync_players)
-                .distributive_run_if(bevy_renet::transport::client_connected)
-                .in_base_set(CoreSet::Update),
+            Main,
+            (player_input, client_send_input, client_sync_players).distributive_run_if(bevy_renet::transport::client_connected),
         );
     }
 
-    app.add_startup_system(setup);
-    app.add_system(panic_on_error_system);
+    app.add_systems(Startup, setup);
+    app.add_systems(Main, panic_on_error_system);
 
     app.run();
 }
@@ -241,7 +240,7 @@ fn client_sync_players(
 fn setup(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>, mut materials: ResMut<Assets<StandardMaterial>>) {
     // plane
     commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(Plane::from_size(5.0))),
+        mesh: meshes.add(shape::Plane::from_size(5.0).into()),
         material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
         ..Default::default()
     });

--- a/bevy_renet/src/lib.rs
+++ b/bevy_renet/src/lib.rs
@@ -24,7 +24,7 @@ impl Plugin for RenetServerPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<Events<ServerEvent>>();
 
-        app.configure_set(Main, RenetSet::Server.run_if(resource_exists::<RenetServer>()));
+        app.configure_set(Update, RenetSet::Server.run_if(resource_exists::<RenetServer>()));
 
         app.add_systems(PreUpdate, Self::update_system.in_set(RenetSet::Server));
     }
@@ -42,7 +42,7 @@ impl RenetServerPlugin {
 
 impl Plugin for RenetClientPlugin {
     fn build(&self, app: &mut App) {
-        app.configure_set(Main, RenetSet::Client.run_if(resource_exists::<RenetClient>()));
+        app.configure_set(Update, RenetSet::Client.run_if(resource_exists::<RenetClient>()));
 
         app.add_systems(PreUpdate, Self::update_system.in_set(RenetSet::Client));
     }

--- a/bevy_renet/src/lib.rs
+++ b/bevy_renet/src/lib.rs
@@ -24,9 +24,9 @@ impl Plugin for RenetServerPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<Events<ServerEvent>>();
 
-        app.configure_set(RenetSet::Server.run_if(resource_exists::<RenetServer>()));
+        app.configure_set(Main, RenetSet::Server.run_if(resource_exists::<RenetServer>()));
 
-        app.add_system(Self::update_system.in_base_set(CoreSet::PreUpdate).in_set(RenetSet::Server));
+        app.add_systems(PreUpdate, Self::update_system.in_set(RenetSet::Server));
     }
 }
 
@@ -42,9 +42,9 @@ impl RenetServerPlugin {
 
 impl Plugin for RenetClientPlugin {
     fn build(&self, app: &mut App) {
-        app.configure_set(RenetSet::Client.run_if(resource_exists::<RenetClient>()));
+        app.configure_set(Main, RenetSet::Client.run_if(resource_exists::<RenetClient>()));
 
-        app.add_system(Self::update_system.in_base_set(CoreSet::PreUpdate).in_set(RenetSet::Client));
+        app.add_systems(PreUpdate, Self::update_system.in_set(RenetSet::Client));
     }
 }
 

--- a/bevy_renet/src/transport.rs
+++ b/bevy_renet/src/transport.rs
@@ -22,7 +22,7 @@ impl Plugin for NetcodeServerPlugin {
     fn build(&self, app: &mut App) {
         app.add_event::<NetcodeTransportError>();
         app.configure_set(
-            Main,
+            Update,
             TransportSet::Server
                 .run_if(resource_exists::<NetcodeServerTransport>().and_then(resource_exists::<RenetServer>()))
                 .after(RenetSet::Server),
@@ -62,7 +62,7 @@ impl Plugin for NetcodeClientPlugin {
         app.add_event::<NetcodeTransportError>();
 
         app.configure_set(
-            Main,
+            Update,
             TransportSet::Client
                 .run_if(resource_exists::<NetcodeClientTransport>().and_then(resource_exists::<RenetClient>()))
                 .after(RenetSet::Client),

--- a/bevy_renet/src/transport.rs
+++ b/bevy_renet/src/transport.rs
@@ -22,18 +22,15 @@ impl Plugin for NetcodeServerPlugin {
     fn build(&self, app: &mut App) {
         app.add_event::<NetcodeTransportError>();
         app.configure_set(
+            Main,
             TransportSet::Server
                 .run_if(resource_exists::<NetcodeServerTransport>().and_then(resource_exists::<RenetServer>()))
                 .after(RenetSet::Server),
         );
 
-        app.add_system(Self::update_system.in_base_set(CoreSet::PreUpdate).in_set(TransportSet::Server));
-        app.add_system(Self::send_packets.in_base_set(CoreSet::PostUpdate).in_set(TransportSet::Server));
-        app.add_system(
-            Self::disconnect_on_exit
-                .in_base_set(CoreSet::PostUpdate)
-                .in_set(TransportSet::Server),
-        );
+        app.add_systems(PreUpdate, Self::update_system.in_set(TransportSet::Server));
+        app.add_systems(PreUpdate, Self::send_packets.in_set(TransportSet::Server));
+        app.add_systems(PostUpdate, Self::disconnect_on_exit.in_set(TransportSet::Server));
     }
 }
 
@@ -65,18 +62,15 @@ impl Plugin for NetcodeClientPlugin {
         app.add_event::<NetcodeTransportError>();
 
         app.configure_set(
+            Main,
             TransportSet::Client
                 .run_if(resource_exists::<NetcodeClientTransport>().and_then(resource_exists::<RenetClient>()))
                 .after(RenetSet::Client),
         );
 
-        app.add_system(Self::update_system.in_base_set(CoreSet::PreUpdate).in_set(TransportSet::Client));
-        app.add_system(Self::send_packets.in_base_set(CoreSet::PostUpdate).in_set(TransportSet::Client));
-        app.add_system(
-            Self::disconnect_on_exit
-                .in_base_set(CoreSet::PostUpdate)
-                .in_set(TransportSet::Client),
-        );
+        app.add_systems(PreUpdate, Self::update_system.in_set(TransportSet::Client));
+        app.add_systems(PostUpdate, Self::send_packets.in_set(TransportSet::Client));
+        app.add_systems(PostUpdate, Self::disconnect_on_exit.in_set(TransportSet::Client));
     }
 }
 

--- a/deny.toml
+++ b/deny.toml
@@ -34,4 +34,5 @@ unknown-git = "deny"
 allow-git = [
     # Used in Demo Bevy, remove when new version supports 0.22
     "https://github.com/mvlabat/bevy_egui.git",
+    "https://github.com/bevyengine/bevy.git",
 ]

--- a/renet/Cargo.toml
+++ b/renet/Cargo.toml
@@ -16,7 +16,7 @@ default = ["transport"]
 transport = ["dep:renetcode"]
 
 [dependencies]
-bevy_ecs = { version = "0.10.1", optional = true }
+bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", optional = true }
 bytes = "1.1"
 log = "0.4.17"
 octets = "0.2"

--- a/renet/Cargo.toml
+++ b/renet/Cargo.toml
@@ -16,7 +16,7 @@ default = ["transport"]
 transport = ["dep:renetcode"]
 
 [dependencies]
-bevy_ecs = { git = "https://github.com/bevyengine/bevy?rev=8ec8149", optional = true }
+bevy_ecs = { git = "https://github.com/bevyengine/bevy?rev=84de9e7", optional = true }
 bytes = "1.1"
 log = "0.4.17"
 octets = "0.2"

--- a/renet/Cargo.toml
+++ b/renet/Cargo.toml
@@ -16,7 +16,7 @@ default = ["transport"]
 transport = ["dep:renetcode"]
 
 [dependencies]
-bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", optional = true }
+bevy_ecs = { git = "https://github.com/bevyengine/bevy?rev=8ec8149", optional = true }
 bytes = "1.1"
 log = "0.4.17"
 octets = "0.2"

--- a/renet/src/server.rs
+++ b/renet/src/server.rs
@@ -8,6 +8,7 @@ use bytes::Bytes;
 
 /// Connection and disconnection events in the server.
 #[derive(Debug)]
+#[cfg_attr(feature = "bevy", derive(bevy_ecs::event::Event))]
 pub enum ServerEvent {
     ClientConnected { client_id: u64 },
     ClientDisconnected { client_id: u64, reason: DisconnectReason },

--- a/renet/src/transport/mod.rs
+++ b/renet/src/transport/mod.rs
@@ -12,6 +12,7 @@ pub use renetcode::{
 };
 
 #[derive(Debug)]
+#[cfg_attr(feature = "bevy", derive(bevy_ecs::event::Event))]
 pub enum NetcodeTransportError {
     Netcode(NetcodeError),
     Renet(crate::DisconnectReason),


### PR DESCRIPTION
Updates renet and bevy_renet to work with bevy main branch, currently 0.11.0-dev. Specifically bevy commit #8ec8149 though this can be updated as new commits are pushed.

Most of the changes are to bevy_renet and do not change any logic, merely adopts new syntax introduced by this version of bevy. 

Only a few #[cfg_attr] changes had to be made in the renet crate to derive bevy resource / events.

Added the bevy git to the whitelist in deny.toml. 

Had to remove "demo_bevy" from the workspace as it depends on other crates that depend on older bevy versions which causes conflicts. There might be a better way to fix this but I haven't got around to it yet. 

Enabled the following bevy features to solve a rendering issue that resulted in all assets missing textures: 
ktx2, tonemapping_luts, zstd

Primarily made this for my own use but added documentation in case anyone else wants to use this. If you decide to merge this I would recommend a separate branch and some changes to the docs will need to be made.