### PR TITLE
Add iterator access to client ids

### DIFF
--- a/renet/src/server.rs
+++ b/renet/src/server.rs
@@ -187,22 +187,24 @@ impl RenetServer {
         None
     }
 
+    /// Return ids for all connected clients (iterator)
+    pub fn clients_id_iter(&self) -> impl Iterator<Item = u64> + '_ {
+        self.connections.iter().filter(|(_, c)| !c.is_disconnected()).map(|(id, _)| *id)
+    }
+
     /// Return ids for all connected clients
     pub fn clients_id(&self) -> Vec<u64> {
-        self.connections
-            .iter()
-            .filter(|(_, c)| !c.is_disconnected())
-            .map(|(id, _)| *id)
-            .collect()
+        self.clients_id_iter().collect()
+    }
+
+    /// Return ids for all disconnected clients (iterator)
+    pub fn disconnections_id_iter(&self) -> impl Iterator<Item = u64> + '_ {
+        self.connections.iter().filter(|(_, c)| c.is_disconnected()).map(|(id, _)| *id)
     }
 
     /// Return ids for all disconnected clients
     pub fn disconnections_id(&self) -> Vec<u64> {
-        self.connections
-            .iter()
-            .filter(|(_, c)| c.is_disconnected())
-            .map(|(id, _)| *id)
-            .collect()
+        self.disconnections_id_iter().collect()
     }
 
     /// Returns the current number of connected clients1.

--- a/renet_visualizer/src/lib.rs
+++ b/renet_visualizer/src/lib.rs
@@ -260,7 +260,7 @@ impl<const N: usize> RenetServerVisualizer<N> {
     /// visualizer.update(&renet_server);
     /// ```
     pub fn update(&mut self, server: &RenetServer) {
-        for client_id in server.clients_id().into_iter() {
+        for client_id in server.clients_id_iter() {
             if let Ok(network_info) = server.network_info(client_id) {
                 self.add_network_info(client_id, network_info);
             }

--- a/renetcode/src/server.rs
+++ b/renetcode/src/server.rs
@@ -504,12 +504,14 @@ impl NetcodeServer {
             .collect()
     }
 
+    /// Returns the ids from the connected clients (iterator).
+    pub fn clients_id_iter(&self) -> impl Iterator<Item = ClientID> + '_ {
+        self.clients.iter().filter_map(|slot| slot.as_ref().map(|client| client.client_id))
+    }
+
     /// Returns the ids from the connected clients.
     pub fn clients_id(&self) -> Vec<ClientID> {
-        self.clients
-            .iter()
-            .filter_map(|slot| slot.as_ref().map(|client| client.client_id))
-            .collect()
+        self.clients_id_iter().collect()
     }
 
     /// Returns the maximum number of clients that can be connected.


### PR DESCRIPTION
Adds iterator access to client ids to avoid vector allocation unless necessary.