### PR TITLE
Add client events

### DIFF
--- a/bevy_renet/src/lib.rs
+++ b/bevy_renet/src/lib.rs
@@ -34,7 +34,27 @@ impl Plugin for RenetClientPlugin {
 }
 
 impl RenetClientPlugin {
-    pub fn update_system(mut client: ResMut<RenetClient>, time: Res<Time>) {
+    pub fn update_system(
+        mut disconnected: Local<bool>,
+        mut client: ResMut<RenetClient>,
+        time: Res<Time>,
+        mut connect_events: EventWriter<ClientConnected>,
+        mut disconnect_events: EventWriter<ClientDisconnected>,
+    ) {
         client.update(time.delta());
+
+        if client.is_disconnected() && !*disconnected {
+            *disconnected = true;
+            disconnect_events.send_default();
+        } else if !client.is_disconnected() && *disconnected {
+            *disconnected = false;
+            connect_events.send_default();
+        }
     }
 }
+
+#[derive(Default, Event)]
+pub struct ClientConnected;
+
+#[derive(Default, Event)]
+pub struct ClientDisconnected;


### PR DESCRIPTION
I added events to react on connection or disconnection.
Useful if you want to close your "connecting to server" message or display "disconnected from server" error on such event. Closes #94.
I used separate structs instead of enum to make it play nicely with `run_if(on_event::<T>())`.