### PR TITLE
Return closures from conditions

### DIFF
--- a/bevy_renet/examples/simple.rs
+++ b/bevy_renet/examples/simple.rs
@@ -115,7 +115,7 @@ fn main() {
 
         app.add_systems(
             Update,
-            (player_input, client_send_input, client_sync_players).run_if(bevy_renet::transport::client_connected),
+            (player_input, client_send_input, client_sync_players).run_if(bevy_renet::transport::client_connected()),
         );
     }
 

--- a/bevy_renet/src/transport.rs
+++ b/bevy_renet/src/transport.rs
@@ -127,28 +127,26 @@ pub fn client_connecting() -> impl FnMut(Option<Res<NetcodeClientTransport>>) ->
 
 pub fn client_just_connected() -> impl FnMut(Local<bool>, Option<Res<NetcodeClientTransport>>) -> bool {
     |mut last_connected: Local<bool>, transport| {
-        let connected = transport.filter(|transport| transport.is_connected()).is_some();
+        let Some(transport) = transport else {
+           return false;
+        };
 
-        if !*last_connected && connected {
-            *last_connected = true;
-            true
-        } else {
-            *last_connected = connected;
-            false
-        }
+        let connected = transport.is_connected();
+        let just_connected = !*last_connected && connected;
+        *last_connected = connected;
+        just_connected
     }
 }
 
 pub fn client_just_diconnected() -> impl FnMut(Local<bool>, Option<Res<NetcodeClientTransport>>) -> bool {
     |mut last_disconnected: Local<bool>, transport| {
-        let disconnected = transport.filter(|transport| !transport.is_disconnected()).is_none();
+        let Some(transport) = transport else {
+           return true;
+        };
 
-        if !*last_disconnected && disconnected {
-            *last_disconnected = true;
-            true
-        } else {
-            *last_disconnected = disconnected;
-            false
-        }
+        let disconnected = transport.is_disconnected();
+        let just_disconnected = !*last_disconnected && disconnected;
+        *last_disconnected = disconnected;
+        just_disconnected
     }
 }

--- a/bevy_renet/src/transport.rs
+++ b/bevy_renet/src/transport.rs
@@ -104,22 +104,22 @@ impl NetcodeClientPlugin {
     }
 }
 
-pub fn client_connected(transport: Option<Res<NetcodeClientTransport>>) -> bool {
-    match transport {
+pub fn client_connected() -> impl FnMut(Option<Res<NetcodeClientTransport>>) -> bool {
+    |transport| match transport {
         Some(transport) => transport.is_connected(),
         None => false,
     }
 }
 
-pub fn client_diconnected(transport: Option<Res<NetcodeClientTransport>>) -> bool {
-    match transport {
+pub fn client_diconnected() -> impl FnMut(Option<Res<NetcodeClientTransport>>) -> bool {
+    |transport| match transport {
         Some(transport) => transport.is_disconnected(),
         None => true,
     }
 }
 
-pub fn client_connecting(transport: Option<Res<NetcodeClientTransport>>) -> bool {
-    match transport {
+pub fn client_connecting() -> impl FnMut(Option<Res<NetcodeClientTransport>>) -> bool {
+    |transport| match transport {
         Some(transport) => transport.is_connecting(),
         None => false,
     }

--- a/bevy_renet/src/transport.rs
+++ b/bevy_renet/src/transport.rs
@@ -124,3 +124,31 @@ pub fn client_connecting() -> impl FnMut(Option<Res<NetcodeClientTransport>>) ->
         None => false,
     }
 }
+
+pub fn client_just_connected() -> impl FnMut(Local<bool>, Option<Res<NetcodeClientTransport>>) -> bool {
+    |mut last_connected: Local<bool>, transport| {
+        let connected = transport.filter(|transport| transport.is_connected()).is_some();
+
+        if !*last_connected && connected {
+            *last_connected = true;
+            true
+        } else {
+            *last_connected = connected;
+            false
+        }
+    }
+}
+
+pub fn client_just_diconnected() -> impl FnMut(Local<bool>, Option<Res<NetcodeClientTransport>>) -> bool {
+    |mut last_disconnected: Local<bool>, transport| {
+        let disconnected = transport.filter(|transport| !transport.is_disconnected()).is_none();
+
+        if !*last_disconnected && disconnected {
+            *last_disconnected = true;
+            true
+        } else {
+            *last_disconnected = disconnected;
+            false
+        }
+    }
+}

--- a/demo_bevy/src/bin/client.rs
+++ b/demo_bevy/src/bin/client.rs
@@ -80,7 +80,7 @@ fn main() {
     app.add_systems(Update, (player_input, camera_follow, update_target_system));
     app.add_systems(
         Update,
-        (client_send_input, client_send_player_commands, client_sync_players).run_if(bevy_renet::transport::client_connected),
+        (client_send_input, client_send_player_commands, client_sync_players).run_if(bevy_renet::transport::client_connected()),
     );
 
     app.insert_resource(RenetClientVisualizer::<200>::new(RenetVisualizerStyle::default()));


### PR DESCRIPTION
In Bevy all conditions done this way. See the [the example](https://github.com/bevyengine/bevy/blob/7fe08535dfe99fb2ff999009bb497db61b5196ec/examples/ecs/run_conditions.rs#L81). Let's make them consistent with the rest of the engine.