### PR TITLE
Handle wildcard source public IP addresses properly

### DIFF
--- a/renetcode/src/server.rs
+++ b/renetcode/src/server.rs
@@ -225,7 +225,13 @@ impl NetcodeServer {
 
         let connect_token = PrivateConnectToken::decode(&data, self.protocol_id, expire_timestamp, &xnonce, &self.connect_key)?;
 
-        let in_host_list = connect_token.server_addresses.iter().any(|host| *host == Some(self.public_address));
+        let in_host_list = (self.public_address.ip().to_string() == "0.0.0.0"
+            && connect_token
+                .server_addresses
+                .iter()
+                .filter(|x| x.is_some())
+                .any(|host| (*host).unwrap().port() == self.public_address.port()))
+            || connect_token.server_addresses.iter().any(|host| *host == Some(self.public_address));
         if !in_host_list {
             return Err(NetcodeError::NotInHostList);
         }


### PR DESCRIPTION
Fixes: #43 

Hi. I believe this check is currently too strict, and we should also handle the wildcard server IP: `0.0.0.0`.

This change checks if our public server IP is `0.0.0.0:<port>`, and will only check the port if that is the case.

I tested this locally by binding to `0.0.0.0:5000`, and setting the public IP to `0.0.0.0:5000` in my `ServerConfig` and was able to receive messages successfully by connecting to `127.0.0.1:5000`. (If I were to port forward, it'd be accessible by `${public-ip}:5000` as well, for example)

Without this, it is quite painful needing to pass in the public IP address of the server, which can change. This doesn't really affect security much since you explicitly need to set your public IP to use this wildcard `0.0.0.0` which just makes testing much more convenient. This also would allow you to connect to your server using your local IP from 1 client, and using your public IP from another (which is currently impossible since we can only set 1 public address)