### PR TITLE
Netcode: allow multiple server addresses and disable host ip check when unsecure

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,12 @@ loop {
 
 ## Demos
 
-You can checkout the [echo example](https://github.com/lucaspoffo/renet/blob/master/renet/examples/echo.rs) for a simple usage of the library. Or you can look into the two demos that have more complex uses of renet:
+You can checkout the [echo example](https://github.com/lucaspoffo/renet/blob/master/renet/examples/echo.rs) for a simple usage of the library. Usage:
+
+- Server: `cargo run --example echo -- server 5000`
+- Client: `cargo run --example echo -- client 127.0.0.1:5000 CoolNickName`
+
+Or you can look into the two demos that have more complex uses of renet:
 
 <details><summary>Bevy Demo</summary>
 <br/>

--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ let mut server = RenetServer::new(ConnectionConfig::default());
 const SERVER_ADDR: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1), 5000));
 let socket: UdpSocket = UdpSocket::bind(SERVER_ADDR).unwrap();
 let server_config = ServerConfig {
-    max_clients:64
+    current_time: SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap(),
+    max_clients: 64
     protocol_id: 0,
-    public_addr: SERVER_ADDR,
+    public_addresses: vec![SERVER_ADDR],
     authentication: ServerAuthentication::Unsecure
 };
-let current_time = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap();
-let mut transport = NetcodeServerTransport::new(current_time, server_config, socket).unwrap();
+let mut transport = NetcodeServerTransport::new(server_config, socket).unwrap();
 
 // Your gameplay loop
 loop {

--- a/bevy_renet/examples/simple.rs
+++ b/bevy_renet/examples/simple.rs
@@ -66,15 +66,16 @@ fn new_renet_server() -> (RenetServer, NetcodeServerTransport) {
 
     let public_addr = "127.0.0.1:5000".parse().unwrap();
     let socket = UdpSocket::bind(public_addr).unwrap();
+    let current_time = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap();
     let server_config = ServerConfig {
+        current_time,
         max_clients: 64,
         protocol_id: PROTOCOL_ID,
-        public_addr,
+        public_addresses: vec![public_addr],
         authentication: ServerAuthentication::Unsecure,
     };
-    let current_time = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap();
 
-    let transport = NetcodeServerTransport::new(current_time, server_config, socket).unwrap();
+    let transport = NetcodeServerTransport::new(server_config, socket).unwrap();
 
     (server, transport)
 }

--- a/demo_bevy/src/bin/server.rs
+++ b/demo_bevy/src/bin/server.rs
@@ -40,15 +40,16 @@ fn new_renet_server() -> (RenetServer, NetcodeServerTransport) {
 
     let public_addr = "127.0.0.1:5000".parse().unwrap();
     let socket = UdpSocket::bind(public_addr).unwrap();
+    let current_time: std::time::Duration = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap();
     let server_config = ServerConfig {
+        current_time,
         max_clients: 64,
         protocol_id: PROTOCOL_ID,
-        public_addr,
+        public_addresses: vec![public_addr],
         authentication: ServerAuthentication::Unsecure,
     };
-    let current_time = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap();
 
-    let transport = NetcodeServerTransport::new(current_time, server_config, socket).unwrap();
+    let transport = NetcodeServerTransport::new(server_config, socket).unwrap();
 
     (server, transport)
 }

--- a/demo_chat/src/server.rs
+++ b/demo_chat/src/server.rs
@@ -26,16 +26,16 @@ pub struct ChatServer {
 impl ChatServer {
     pub fn new(host_username: String) -> Self {
         let socket = UdpSocket::bind("127.0.0.1:0").unwrap();
-        let public_addr = socket.local_addr().unwrap();
+        let current_time = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap();
         let server_config = ServerConfig {
+            current_time,
             max_clients: 64,
             protocol_id: PROTOCOL_ID,
-            public_addr,
+            public_addresses: vec![socket.local_addr().unwrap()],
             authentication: ServerAuthentication::Unsecure,
         };
 
-        let current_time = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap();
-        let transport = NetcodeServerTransport::new(current_time, server_config, socket).unwrap();
+        let transport = NetcodeServerTransport::new(server_config, socket).unwrap();
 
         let server: RenetServer = RenetServer::new(ConnectionConfig::default());
 

--- a/demo_chat/src/ui.rs
+++ b/demo_chat/src/ui.rs
@@ -51,14 +51,15 @@ pub fn draw_host_commands(ui: &mut Ui, chat_server: &mut ChatServer) {
     });
 
     ui.separator();
-    ui.horizontal(|ui| {
-        let server_addr = chat_server.transport.addr();
-        ui.label(format!("Address: {}", server_addr));
-        let tooltip = "Click to copy the server address";
-        if ui.button("📋").on_hover_text(tooltip).clicked() {
-            ui.output_mut(|output| output.copied_text = server_addr.to_string());
-        }
-    });
+    for server_addr in chat_server.transport.addresses() {
+        ui.horizontal(|ui| {
+            ui.label(format!("Address: {}", server_addr));
+            let tooltip = "Click to copy the server address";
+            if ui.button("📋").on_hover_text(tooltip).clicked() {
+                ui.output_mut(|output| output.copied_text = server_addr.to_string());
+            }
+        });
+    }
 
     ui.separator();
 

--- a/renet/examples/echo.rs
+++ b/renet/examples/echo.rs
@@ -67,15 +67,17 @@ fn server(public_addr: SocketAddr) {
     let connection_config = ConnectionConfig::default();
     let mut server: RenetServer = RenetServer::new(connection_config);
 
-    let socket: UdpSocket = UdpSocket::bind(public_addr).unwrap();
+    let current_time = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap();
     let server_config = ServerConfig {
+        current_time,
         max_clients: 64,
         protocol_id: PROTOCOL_ID,
-        public_addr,
+        public_addresses: vec![public_addr],
         authentication: ServerAuthentication::Unsecure,
     };
-    let current_time = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap();
-    let mut transport = NetcodeServerTransport::new(current_time, server_config, socket).unwrap();
+    let socket: UdpSocket = UdpSocket::bind(public_addr).unwrap();
+
+    let mut transport = NetcodeServerTransport::new(server_config, socket).unwrap();
 
     let mut usernames: HashMap<u64, String> = HashMap::new();
     let mut received_messages = vec![];

--- a/renet/examples/echo.rs
+++ b/renet/examples/echo.rs
@@ -41,18 +41,18 @@ impl Username {
 
 fn main() {
     env_logger::init();
-    println!("Usage: server [SERVER_PORT] or client [SERVER_PORT] [USER_NAME]");
+    println!("Usage: server [SERVER_PORT] or client [SERVER_ADDR] [USER_NAME]");
     let args: Vec<String> = std::env::args().collect();
 
     let exec_type = &args[1];
     match exec_type.as_str() {
         "client" => {
-            let server_addr: SocketAddr = format!("127.0.0.1:{}", args[2]).parse().unwrap();
+            let server_addr: SocketAddr = args[2].parse().unwrap();
             let username = Username(args[3].clone());
             client(server_addr, username);
         }
         "server" => {
-            let server_addr: SocketAddr = format!("127.0.0.1:{}", args[2]).parse().unwrap();
+            let server_addr: SocketAddr = format!("0.0.0.0:{}", args[2]).parse().unwrap();
             server(server_addr);
         }
         _ => {

--- a/renet/src/transport/mod.rs
+++ b/renet/src/transport/mod.rs
@@ -7,8 +7,8 @@ pub use client::*;
 pub use server::*;
 
 pub use renetcode::{
-    generate_random_bytes, ConnectToken, DisconnectReason as NetcodeDisconnectReason, NetcodeError, TokenGenerationError,
-    NETCODE_KEY_BYTES, NETCODE_USER_DATA_BYTES,
+    generate_random_bytes, ClientAuthentication, ConnectToken, DisconnectReason as NetcodeDisconnectReason, NetcodeError,
+    ServerAuthentication, ServerConfig, TokenGenerationError, NETCODE_KEY_BYTES, NETCODE_USER_DATA_BYTES,
 };
 
 #[derive(Debug)]

--- a/renetcode/src/lib.rs
+++ b/renetcode/src/lib.rs
@@ -25,10 +25,10 @@ mod serialize;
 mod server;
 mod token;
 
-pub use client::{DisconnectReason, NetcodeClient};
+pub use client::{ClientAuthentication, DisconnectReason, NetcodeClient};
 pub use crypto::generate_random_bytes;
 pub use error::NetcodeError;
-pub use server::{NetcodeServer, ServerResult};
+pub use server::{NetcodeServer, ServerAuthentication, ServerConfig, ServerResult};
 pub use token::{ConnectToken, TokenGenerationError};
 
 use std::time::Duration;

--- a/renetcode/src/server.rs
+++ b/renetcode/src/server.rs
@@ -106,8 +106,7 @@ pub struct ServerConfig {
     /// You can use a hash function with the current version of the game to generate this value
     /// so that older versions cannot connect to newer versions.
     pub protocol_id: u64,
-    /// Publicly available address to which clients will attempt to connect. This is
-    /// the address used to generate the ConnectToken.
+    /// Publicly available addresses to which clients will attempt to connect.
     pub public_addresses: Vec<SocketAddr>,
     /// Authentication configuration for the server
     pub authentication: ServerAuthentication,


### PR DESCRIPTION
Alternative solution for #78 and #101

We now allow multiple server addresses in the server.
We skip the host check when we are using unsecure connections.

This should allow more flexibility and easier testing while keeping the security.
Wildcard is probably something we should not support since the host check would not be secure, but with multiple server addresses we achieve similar results.

We also moved the authentication configuration to the `renetcode` crate.