### PR TITLE
Switch from using `u64` client id to wrapper `ClientId` type

### DIFF
--- a/bevy_renet/Cargo.toml
+++ b/bevy_renet/Cargo.toml
@@ -12,11 +12,16 @@ version = "0.0.9"
 
 [features]
 default = ["transport"]
+serde = ["renet/serde"]
 transport = ["renet/transport"]
+
+[[example]]
+name = "simple"
+required-features = ["serde", "transport"]
 
 [dependencies]
 bevy = {version = "0.11", default-features = false}
-renet = {path = "../renet", version = "0.0.13", features = ["bevy", "serde"]}
+renet = {path = "../renet", version = "0.0.13", features = ["bevy"]}
 
 [dev-dependencies]
 bevy = {version = "0.11", default-features = false, features = ["bevy_core_pipeline", "bevy_render", "bevy_asset", "bevy_pbr", "x11", "tonemapping_luts", "ktx2", "zstd"]}

--- a/bevy_renet/Cargo.toml
+++ b/bevy_renet/Cargo.toml
@@ -16,7 +16,7 @@ transport = ["renet/transport"]
 
 [dependencies]
 bevy = {version = "0.11", default-features = false}
-renet = {path = "../renet", version = "0.0.13", features = ["bevy"]}
+renet = {path = "../renet", version = "0.0.13", features = ["bevy", "serde"]}
 
 [dev-dependencies]
 bevy = {version = "0.11", default-features = false, features = ["bevy_core_pipeline", "bevy_render", "bevy_asset", "bevy_pbr", "x11", "tonemapping_luts", "ktx2", "zstd"]}

--- a/bevy_renet/examples/simple.rs
+++ b/bevy_renet/examples/simple.rs
@@ -9,7 +9,7 @@ use bevy_renet::{
 };
 use renet::{
     transport::{NetcodeClientTransport, NetcodeServerTransport, NetcodeTransportError},
-    NetworkId,
+    ClientId,
 };
 
 use std::time::SystemTime;
@@ -31,18 +31,18 @@ struct PlayerInput {
 
 #[derive(Debug, Component)]
 struct Player {
-    id: NetworkId,
+    id: ClientId,
 }
 
 #[derive(Debug, Default, Resource)]
 struct Lobby {
-    players: HashMap<NetworkId, Entity>,
+    players: HashMap<ClientId, Entity>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Component)]
 enum ServerMessages {
-    PlayerConnected { id: NetworkId },
-    PlayerDisconnected { id: NetworkId },
+    PlayerConnected { id: ClientId },
+    PlayerDisconnected { id: ClientId },
 }
 
 fn new_renet_client() -> (RenetClient, NetcodeClientTransport) {

--- a/bevy_renet/examples/simple.rs
+++ b/bevy_renet/examples/simple.rs
@@ -41,8 +41,8 @@ struct Lobby {
 
 #[derive(Debug, Serialize, Deserialize, Component)]
 enum ServerMessages {
-    PlayerConnected { id: u64 },
-    PlayerDisconnected { id: u64 },
+    PlayerConnected { id: NetworkId },
+    PlayerDisconnected { id: NetworkId },
 }
 
 fn new_renet_client() -> (RenetClient, NetcodeClientTransport) {
@@ -156,13 +156,13 @@ fn server_update_system(
                 // We could send an InitState with all the players id and positions for the client
                 // but this is easier to do.
                 for &player_id in lobby.players.keys() {
-                    let message = bincode::serialize(&ServerMessages::PlayerConnected { id: player_id.raw() }).unwrap();
+                    let message = bincode::serialize(&ServerMessages::PlayerConnected { id: player_id }).unwrap();
                     server.send_message(*client_id, DefaultChannel::ReliableOrdered, message);
                 }
 
                 lobby.players.insert(*client_id, player_entity);
 
-                let message = bincode::serialize(&ServerMessages::PlayerConnected { id: client_id.raw() }).unwrap();
+                let message = bincode::serialize(&ServerMessages::PlayerConnected { id: *client_id }).unwrap();
                 server.broadcast_message(DefaultChannel::ReliableOrdered, message);
             }
             ServerEvent::ClientDisconnected { client_id, reason } => {
@@ -171,7 +171,7 @@ fn server_update_system(
                     commands.entity(player_entity).despawn();
                 }
 
-                let message = bincode::serialize(&ServerMessages::PlayerDisconnected { id: client_id.raw() }).unwrap();
+                let message = bincode::serialize(&ServerMessages::PlayerDisconnected { id: *client_id }).unwrap();
                 server.broadcast_message(DefaultChannel::ReliableOrdered, message);
             }
         }

--- a/demo_bevy/Cargo.toml
+++ b/demo_bevy/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/bin/server.rs"
 [dependencies]
 bevy_rapier3d = "0.22.0"
 bevy = {version = "0.11", default-features = false, features = ["bevy_core_pipeline", "bevy_render", "bevy_asset", "bevy_pbr", "x11", "tonemapping_luts", "ktx2", "zstd"]}
-bevy_renet = { path = "../bevy_renet" }
+bevy_renet = { path = "../bevy_renet", features = ["transport", "serde"] }
 serde = { version = "1.0", features = [ "derive" ] }
 bincode = "1.3.1"
 # Use version directly when egui is updated to 0.22

--- a/demo_bevy/src/bin/client.rs
+++ b/demo_bevy/src/bin/client.rs
@@ -9,7 +9,7 @@ use bevy_egui::{EguiContexts, EguiPlugin};
 use bevy_renet::{
     renet::{
         transport::{ClientAuthentication, NetcodeClientTransport, NetcodeTransportError},
-        RenetClient,
+        ClientId, RenetClient,
     },
     transport::NetcodeClientPlugin,
     RenetClientPlugin,
@@ -35,7 +35,7 @@ struct PlayerInfo {
 
 #[derive(Debug, Default, Resource)]
 struct ClientLobby {
-    players: HashMap<u64, PlayerInfo>,
+    players: HashMap<ClientId, PlayerInfo>,
 }
 
 fn new_renet_client() -> (RenetClient, NetcodeClientTransport) {
@@ -170,7 +170,7 @@ fn client_sync_players(
                     ..Default::default()
                 });
 
-                if client_id == id {
+                if client_id == id.raw() {
                     client_entity.insert(ControlledPlayer);
                 }
 

--- a/demo_bevy/src/bin/server.rs
+++ b/demo_bevy/src/bin/server.rs
@@ -9,7 +9,7 @@ use bevy_rapier3d::prelude::*;
 use bevy_renet::{
     renet::{
         transport::{NetcodeServerTransport, ServerAuthentication, ServerConfig},
-        NetworkId, RenetServer, ServerEvent,
+        ClientId, RenetServer, ServerEvent,
     },
     transport::NetcodeServerPlugin,
     RenetServerPlugin,
@@ -22,7 +22,7 @@ use renet_visualizer::RenetServerVisualizer;
 
 #[derive(Debug, Default, Resource)]
 pub struct ServerLobby {
-    pub players: HashMap<NetworkId, Entity>,
+    pub players: HashMap<ClientId, Entity>,
 }
 
 const PLAYER_MOVE_SPEED: f32 = 5.0;

--- a/demo_bevy/src/bin/server.rs
+++ b/demo_bevy/src/bin/server.rs
@@ -117,7 +117,7 @@ fn server_update_system(
                 for (entity, player, transform) in players.iter() {
                     let translation: [f32; 3] = transform.translation.into();
                     let message = bincode::serialize(&ServerMessages::PlayerCreate {
-                        id: player.id.raw(),
+                        id: player.id,
                         entity,
                         translation,
                     })
@@ -146,7 +146,7 @@ fn server_update_system(
 
                 let translation: [f32; 3] = transform.translation.into();
                 let message = bincode::serialize(&ServerMessages::PlayerCreate {
-                    id: client_id.raw(),
+                    id: *client_id,
                     entity: player_entity,
                     translation,
                 })
@@ -160,7 +160,7 @@ fn server_update_system(
                     commands.entity(player_entity).despawn();
                 }
 
-                let message = bincode::serialize(&ServerMessages::PlayerRemove { id: client_id.raw() }).unwrap();
+                let message = bincode::serialize(&ServerMessages::PlayerRemove { id: *client_id }).unwrap();
                 server.broadcast_message(ServerChannel::ServerMessages, message);
             }
         }
@@ -282,7 +282,7 @@ fn spawn_bot(
     mut commands: Commands,
 ) {
     if keyboard_input.just_pressed(KeyCode::Space) {
-        let client_id = bot_id.0.into();
+        let client_id = ClientId::from_raw(bot_id.0);
         bot_id.0 += 1;
         // Spawn new player
         let transform = Transform::from_xyz((fastrand::f32() - 0.5) * 40., 0.51, (fastrand::f32() - 0.5) * 40.);
@@ -306,7 +306,7 @@ fn spawn_bot(
 
         let translation: [f32; 3] = transform.translation.into();
         let message = bincode::serialize(&ServerMessages::PlayerCreate {
-            id: client_id.raw(),
+            id: client_id,
             entity: player_entity,
             translation,
         })

--- a/demo_bevy/src/lib.rs
+++ b/demo_bevy/src/lib.rs
@@ -2,7 +2,7 @@ use std::{f32::consts::PI, time::Duration};
 
 use bevy::prelude::{shape::Icosphere, *};
 use bevy_rapier3d::prelude::*;
-use bevy_renet::renet::{transport::NETCODE_KEY_BYTES, ChannelConfig, ConnectionConfig, NetworkId, SendType};
+use bevy_renet::renet::{transport::NETCODE_KEY_BYTES, ChannelConfig, ClientId, ConnectionConfig, SendType};
 use serde::{Deserialize, Serialize};
 
 pub const PRIVATE_KEY: &[u8; NETCODE_KEY_BYTES] = b"an example very very secret key."; // 32-bytes
@@ -10,7 +10,7 @@ pub const PROTOCOL_ID: u64 = 7;
 
 #[derive(Debug, Component)]
 pub struct Player {
-    pub id: NetworkId,
+    pub id: ClientId,
 }
 
 #[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, Component, Resource)]

--- a/demo_bevy/src/lib.rs
+++ b/demo_bevy/src/lib.rs
@@ -2,7 +2,7 @@ use std::{f32::consts::PI, time::Duration};
 
 use bevy::prelude::{shape::Icosphere, *};
 use bevy_rapier3d::prelude::*;
-use bevy_renet::renet::{transport::NETCODE_KEY_BYTES, ChannelConfig, ConnectionConfig, SendType};
+use bevy_renet::renet::{transport::NETCODE_KEY_BYTES, ChannelConfig, ConnectionConfig, NetworkId, SendType};
 use serde::{Deserialize, Serialize};
 
 pub const PRIVATE_KEY: &[u8; NETCODE_KEY_BYTES] = b"an example very very secret key."; // 32-bytes
@@ -10,7 +10,7 @@ pub const PROTOCOL_ID: u64 = 7;
 
 #[derive(Debug, Component)]
 pub struct Player {
-    pub id: u64,
+    pub id: NetworkId,
 }
 
 #[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, Component, Resource)]

--- a/demo_bevy/src/lib.rs
+++ b/demo_bevy/src/lib.rs
@@ -38,10 +38,21 @@ pub enum ServerChannel {
 
 #[derive(Debug, Serialize, Deserialize, Component)]
 pub enum ServerMessages {
-    PlayerCreate { entity: Entity, id: u64, translation: [f32; 3] },
-    PlayerRemove { id: u64 },
-    SpawnProjectile { entity: Entity, translation: [f32; 3] },
-    DespawnProjectile { entity: Entity },
+    PlayerCreate {
+        entity: Entity,
+        id: ClientId,
+        translation: [f32; 3],
+    },
+    PlayerRemove {
+        id: ClientId,
+    },
+    SpawnProjectile {
+        entity: Entity,
+        translation: [f32; 3],
+    },
+    DespawnProjectile {
+        entity: Entity,
+    },
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]

--- a/demo_chat/Cargo.toml
+++ b/demo_chat/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-renet = { path = "../renet" }
+renet = { path = "../renet", features = [ "transport", "serde" ] }
 renet_visualizer = { path = "../renet_visualizer" }
 eframe = "0.22"
 serde = { version = "1.0", features = [ "derive" ] } 

--- a/demo_chat/src/client.rs
+++ b/demo_chat/src/client.rs
@@ -1,7 +1,7 @@
 use bincode::Options;
 use eframe::egui;
 use log::error;
-use renet::{transport::NetcodeClientTransport, DefaultChannel, NetworkId, RenetClient};
+use renet::{transport::NetcodeClientTransport, ClientId, DefaultChannel, RenetClient};
 use renet_visualizer::RenetClientVisualizer;
 
 use std::{collections::HashMap, time::Instant};
@@ -26,7 +26,7 @@ pub enum AppState {
     ClientChat {
         client: Box<RenetClient>,
         transport: Box<NetcodeClientTransport>,
-        usernames: HashMap<NetworkId, String>,
+        usernames: HashMap<ClientId, String>,
         messages: Vec<Message>,
         visualizer: Box<RenetClientVisualizer<240>>,
     },

--- a/demo_chat/src/client.rs
+++ b/demo_chat/src/client.rs
@@ -99,19 +99,19 @@ impl ChatApp {
                         let message: ServerMessages = bincode::options().deserialize(&message).unwrap();
                         match message {
                             ServerMessages::ClientConnected { client_id, username } => {
-                                usernames.insert(client_id.into(), username);
+                                usernames.insert(client_id, username);
                             }
                             ServerMessages::ClientDisconnected { client_id } => {
-                                usernames.remove(&client_id.into());
+                                usernames.remove(&client_id);
                                 let text = format!("client {} disconnect", client_id);
-                                messages.push(Message::new(0, text));
+                                messages.push(Message::new(0.into(), text));
                             }
                             ServerMessages::ClientMessage(message) => {
                                 messages.push(message);
                             }
                             ServerMessages::InitClient { usernames: init_usernames } => {
                                 self.ui_state.error = None;
-                                *usernames = HashMap::from_iter(init_usernames.iter().map(|(id, a)| (id.into(), a.clone())));
+                                *usernames = init_usernames;
                             }
                         }
                     }

--- a/demo_chat/src/client.rs
+++ b/demo_chat/src/client.rs
@@ -7,7 +7,7 @@ use renet_visualizer::RenetClientVisualizer;
 use std::{collections::HashMap, time::Instant};
 
 use crate::{
-    server::ChatServer,
+    server::{ChatServer, SYSTEM_MESSAGE_CLIENT_ID},
     ui::{draw_chat, draw_loader, draw_main_screen},
     Message, ServerMessages,
 };
@@ -104,7 +104,7 @@ impl ChatApp {
                             ServerMessages::ClientDisconnected { client_id } => {
                                 usernames.remove(&client_id);
                                 let text = format!("client {} disconnect", client_id);
-                                messages.push(Message::new(0.into(), text));
+                                messages.push(Message::new(SYSTEM_MESSAGE_CLIENT_ID, text));
                             }
                             ServerMessages::ClientMessage(message) => {
                                 messages.push(message);

--- a/demo_chat/src/main.rs
+++ b/demo_chat/src/main.rs
@@ -1,6 +1,6 @@
 use client::ChatApp;
 use eframe::{egui, App};
-use renet::transport::NETCODE_USER_DATA_BYTES;
+use renet::{transport::NETCODE_USER_DATA_BYTES, NetworkId};
 use serde::{Deserialize, Serialize};
 
 use std::collections::HashMap;
@@ -16,7 +16,7 @@ pub struct Username(pub String);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Message {
-    client_id: u64,
+    client_id: NetworkId,
     text: String,
 }
 
@@ -27,14 +27,14 @@ enum ClientMessages {
 
 #[derive(Debug, Serialize, Deserialize)]
 enum ServerMessages {
-    ClientConnected { client_id: u64, username: String },
-    ClientDisconnected { client_id: u64 },
+    ClientConnected { client_id: NetworkId, username: String },
+    ClientDisconnected { client_id: NetworkId },
     ClientMessage(Message),
-    InitClient { usernames: HashMap<u64, String> },
+    InitClient { usernames: HashMap<NetworkId, String> },
 }
 
 impl Message {
-    fn new(client_id: u64, text: String) -> Self {
+    fn new(client_id: NetworkId, text: String) -> Self {
         Self { client_id, text }
     }
 }

--- a/demo_chat/src/main.rs
+++ b/demo_chat/src/main.rs
@@ -1,6 +1,6 @@
 use client::ChatApp;
 use eframe::{egui, App};
-use renet::{transport::NETCODE_USER_DATA_BYTES, NetworkId};
+use renet::{transport::NETCODE_USER_DATA_BYTES, ClientId};
 use serde::{Deserialize, Serialize};
 
 use std::collections::HashMap;
@@ -16,7 +16,7 @@ pub struct Username(pub String);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Message {
-    client_id: NetworkId,
+    client_id: ClientId,
     text: String,
 }
 
@@ -27,14 +27,14 @@ enum ClientMessages {
 
 #[derive(Debug, Serialize, Deserialize)]
 enum ServerMessages {
-    ClientConnected { client_id: NetworkId, username: String },
-    ClientDisconnected { client_id: NetworkId },
+    ClientConnected { client_id: ClientId, username: String },
+    ClientDisconnected { client_id: ClientId },
     ClientMessage(Message),
-    InitClient { usernames: HashMap<NetworkId, String> },
+    InitClient { usernames: HashMap<ClientId, String> },
 }
 
 impl Message {
-    fn new(client_id: NetworkId, text: String) -> Self {
+    fn new(client_id: ClientId, text: String) -> Self {
         Self { client_id, text }
     }
 }

--- a/demo_chat/src/server.rs
+++ b/demo_chat/src/server.rs
@@ -15,6 +15,9 @@ use crate::{ClientMessages, Message, ServerMessages, Username, PROTOCOL_ID};
 use bincode::Options;
 use log::info;
 
+pub const SYSTEM_MESSAGE_CLIENT_ID: ClientId = ClientId::from_raw(0);
+pub const HOST_CLIENT_ID: ClientId = ClientId::from_raw(1);
+
 pub struct ChatServer {
     pub server: RenetServer,
     pub transport: NetcodeServerTransport,
@@ -40,7 +43,7 @@ impl ChatServer {
         let server: RenetServer = RenetServer::new(ConnectionConfig::default());
 
         let mut usernames = HashMap::new();
-        usernames.insert(ClientId::from_raw(1), host_username);
+        usernames.insert(HOST_CLIENT_ID, host_username);
 
         Self {
             server,

--- a/demo_chat/src/server.rs
+++ b/demo_chat/src/server.rs
@@ -7,7 +7,7 @@ use std::{
 
 use renet::{
     transport::{NetcodeServerTransport, ServerAuthentication, ServerConfig},
-    ConnectionConfig, DefaultChannel, NetworkId, RenetServer, ServerEvent,
+    ClientId, ConnectionConfig, DefaultChannel, RenetServer, ServerEvent,
 };
 use renet_visualizer::RenetServerVisualizer;
 
@@ -18,7 +18,7 @@ use log::info;
 pub struct ChatServer {
     pub server: RenetServer,
     pub transport: NetcodeServerTransport,
-    pub usernames: HashMap<NetworkId, String>,
+    pub usernames: HashMap<ClientId, String>,
     pub messages: Vec<Message>,
     pub visualizer: RenetServerVisualizer<240>,
 }
@@ -40,7 +40,7 @@ impl ChatServer {
         let server: RenetServer = RenetServer::new(ConnectionConfig::default());
 
         let mut usernames = HashMap::new();
-        usernames.insert(NetworkId::from_raw(1), host_username);
+        usernames.insert(ClientId::from_raw(1), host_username);
 
         Self {
             server,
@@ -101,7 +101,7 @@ impl ChatServer {
         Ok(())
     }
 
-    pub fn receive_message(&mut self, client_id: NetworkId, text: String) {
+    pub fn receive_message(&mut self, client_id: ClientId, text: String) {
         let message = Message::new(client_id, text);
         self.messages.push(message.clone());
         let message = bincode::options().serialize(&ServerMessages::ClientMessage(message)).unwrap();

--- a/demo_chat/src/ui.rs
+++ b/demo_chat/src/ui.rs
@@ -215,7 +215,7 @@ pub fn draw_chat(ui_state: &mut UiState, state: &mut AppState, usernames: HashMa
             let text = ui_state.text_input.clone();
             match state {
                 AppState::HostChat { chat_server } => {
-                    chat_server.receive_message(1, text);
+                    chat_server.receive_message(1.into(), text);
                 }
                 AppState::ClientChat { client, .. } => {
                     let message = bincode::options().serialize(&ClientMessages::Text(text)).unwrap();
@@ -238,9 +238,9 @@ pub fn draw_chat(ui_state: &mut UiState, state: &mut AppState, usernames: HashMa
                     _ => unreachable!(),
                 };
                 for message in messages.iter() {
-                    let text = if let Some(username) = usernames.get(&message.client_id.into()) {
+                    let text = if let Some(username) = usernames.get(&message.client_id) {
                         format!("{}: {}", username, message.text)
-                    } else if message.client_id == 0 {
+                    } else if message.client_id.raw() == 0 {
                         format!("Server: {}", message.text)
                     } else {
                         format!("unknown: {}", message.text)

--- a/demo_chat/src/ui.rs
+++ b/demo_chat/src/ui.rs
@@ -5,7 +5,7 @@ use eframe::{
 };
 use renet::{
     transport::{ClientAuthentication, NetcodeClientTransport},
-    ConnectionConfig, DefaultChannel, RenetClient,
+    ConnectionConfig, DefaultChannel, NetworkId, RenetClient,
 };
 
 use std::{
@@ -138,7 +138,7 @@ pub fn draw_main_screen(ui_state: &mut UiState, state: &mut AppState, ctx: &egui
     });
 }
 
-pub fn draw_chat(ui_state: &mut UiState, state: &mut AppState, usernames: HashMap<u64, String>, ctx: &egui::Context) {
+pub fn draw_chat(ui_state: &mut UiState, state: &mut AppState, usernames: HashMap<NetworkId, String>, ctx: &egui::Context) {
     if ui_state.show_network_info {
         match state {
             AppState::ClientChat { visualizer, .. } => {
@@ -238,7 +238,7 @@ pub fn draw_chat(ui_state: &mut UiState, state: &mut AppState, usernames: HashMa
                     _ => unreachable!(),
                 };
                 for message in messages.iter() {
-                    let text = if let Some(username) = usernames.get(&message.client_id) {
+                    let text = if let Some(username) = usernames.get(&message.client_id.into()) {
                         format!("{}: {}", username, message.text)
                     } else if message.client_id == 0 {
                         format!("Server: {}", message.text)

--- a/demo_chat/src/ui.rs
+++ b/demo_chat/src/ui.rs
@@ -5,7 +5,7 @@ use eframe::{
 };
 use renet::{
     transport::{ClientAuthentication, NetcodeClientTransport},
-    ConnectionConfig, DefaultChannel, NetworkId, RenetClient,
+    ClientId, ConnectionConfig, DefaultChannel, RenetClient,
 };
 
 use std::{
@@ -138,7 +138,7 @@ pub fn draw_main_screen(ui_state: &mut UiState, state: &mut AppState, ctx: &egui
     });
 }
 
-pub fn draw_chat(ui_state: &mut UiState, state: &mut AppState, usernames: HashMap<NetworkId, String>, ctx: &egui::Context) {
+pub fn draw_chat(ui_state: &mut UiState, state: &mut AppState, usernames: HashMap<ClientId, String>, ctx: &egui::Context) {
     if ui_state.show_network_info {
         match state {
             AppState::ClientChat { visualizer, .. } => {

--- a/demo_chat/src/ui.rs
+++ b/demo_chat/src/ui.rs
@@ -16,7 +16,7 @@ use std::{
 
 use crate::{
     client::{AppState, UiState},
-    server::ChatServer,
+    server::{ChatServer, HOST_CLIENT_ID, SYSTEM_MESSAGE_CLIENT_ID},
 };
 use crate::{ClientMessages, Username, PROTOCOL_ID};
 
@@ -215,7 +215,8 @@ pub fn draw_chat(ui_state: &mut UiState, state: &mut AppState, usernames: HashMa
             let text = ui_state.text_input.clone();
             match state {
                 AppState::HostChat { chat_server } => {
-                    chat_server.receive_message(1.into(), text);
+                    // Simulate receiving a message sent by the host
+                    chat_server.receive_message(HOST_CLIENT_ID, text);
                 }
                 AppState::ClientChat { client, .. } => {
                     let message = bincode::options().serialize(&ClientMessages::Text(text)).unwrap();
@@ -240,7 +241,7 @@ pub fn draw_chat(ui_state: &mut UiState, state: &mut AppState, usernames: HashMa
                 for message in messages.iter() {
                     let text = if let Some(username) = usernames.get(&message.client_id) {
                         format!("{}: {}", username, message.text)
-                    } else if message.client_id.raw() == 0 {
+                    } else if message.client_id == SYSTEM_MESSAGE_CLIENT_ID {
                         format!("Server: {}", message.text)
                     } else {
                         format!("unknown: {}", message.text)

--- a/renet/Cargo.toml
+++ b/renet/Cargo.toml
@@ -14,6 +14,7 @@ version = "0.0.13"
 bevy = ["dep:bevy_ecs"]
 default = ["transport"]
 transport = ["dep:renetcode"]
+serde = ["dep:serde"]
 
 [dependencies]
 bevy_ecs = { version = "0.11", optional = true }
@@ -21,6 +22,7 @@ bytes = "1.1"
 log = "0.4.17"
 octets = "0.2"
 renetcode = { path = "../renetcode", version = "0.0.9", optional = true }
+serde = {version = "1.0", optional = true}
 
 [dev-dependencies]
 env_logger = "0.10.0"

--- a/renet/examples/echo.rs
+++ b/renet/examples/echo.rs
@@ -98,12 +98,12 @@ fn server(public_addr: SocketAddr) {
                 ServerEvent::ClientConnected { client_id } => {
                     let user_data = transport.user_data(client_id).unwrap();
                     let username = Username::from_user_data(&user_data);
-                    usernames.insert(client_id, username.0);
+                    usernames.insert(client_id.raw(), username.0);
                     println!("Client {} connected.", client_id)
                 }
                 ServerEvent::ClientDisconnected { client_id, reason } => {
                     println!("Client {} disconnected: {}", client_id, reason);
-                    usernames.remove_entry(&client_id);
+                    usernames.remove_entry(&client_id.raw());
                 }
             }
         }
@@ -111,7 +111,7 @@ fn server(public_addr: SocketAddr) {
         for client_id in server.clients_id() {
             while let Some(message) = server.receive_message(client_id, DefaultChannel::ReliableOrdered) {
                 let text = String::from_utf8(message.into()).unwrap();
-                let username = usernames.get(&client_id).unwrap();
+                let username = usernames.get(&client_id.raw()).unwrap();
                 println!("Client {} ({}) sent text: {}", username, client_id, text);
                 let text = format!("{}: {}", username, text);
                 received_messages.push(text);

--- a/renet/src/lib.rs
+++ b/renet/src/lib.rs
@@ -11,6 +11,6 @@ pub mod transport;
 pub use channel::{ChannelConfig, DefaultChannel, SendType};
 pub use error::{ChannelError, ClientNotFound, DisconnectReason};
 pub use remote_connection::{ConnectionConfig, NetworkInfo, RenetClient};
-pub use server::{RenetServer, ServerEvent};
+pub use server::{NetworkId, RenetServer, ServerEvent};
 
 pub use bytes::Bytes;

--- a/renet/src/lib.rs
+++ b/renet/src/lib.rs
@@ -11,6 +11,6 @@ pub mod transport;
 pub use channel::{ChannelConfig, DefaultChannel, SendType};
 pub use error::{ChannelError, ClientNotFound, DisconnectReason};
 pub use remote_connection::{ConnectionConfig, NetworkInfo, RenetClient};
-pub use server::{NetworkId, RenetServer, ServerEvent};
+pub use server::{ClientId, RenetServer, ServerEvent};
 
 pub use bytes::Bytes;

--- a/renet/src/lib.rs
+++ b/renet/src/lib.rs
@@ -11,6 +11,48 @@ pub mod transport;
 pub use channel::{ChannelConfig, DefaultChannel, SendType};
 pub use error::{ChannelError, ClientNotFound, DisconnectReason};
 pub use remote_connection::{ConnectionConfig, NetworkInfo, RenetClient};
-pub use server::{ClientId, RenetServer, ServerEvent};
+pub use server::{RenetServer, ServerEvent};
 
 pub use bytes::Bytes;
+
+/// Unique identifier for clients.
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Ord, PartialOrd)]
+pub struct ClientId(u64);
+
+impl ClientId {
+    /// Creates a [`ClientId`] from a raw 64 bit value.
+    pub const fn from_raw(value: u64) -> Self {
+        Self(value)
+    }
+
+    /// Returns the raw 64 bit value of the [`ClientId`]
+    pub fn raw(&self) -> u64 {
+        self.0
+    }
+}
+
+impl std::fmt::Display for ClientId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for ClientId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for ClientId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        u64::deserialize(deserializer).map(ClientId::from_raw)
+    }
+}

--- a/renet/src/server.rs
+++ b/renet/src/server.rs
@@ -54,7 +54,7 @@ impl<'de> serde::Deserialize<'de> for NetworkId {
     where
         D: serde::Deserializer<'de>,
     {
-        u64::deserialize(deserializer).map(|id| NetworkId(id))
+        u64::deserialize(deserializer).map(NetworkId::from_raw)
     }
 }
 

--- a/renet/src/server.rs
+++ b/renet/src/server.rs
@@ -38,6 +38,26 @@ impl Display for NetworkId {
     }
 }
 
+#[cfg(feature = "serde")]
+impl serde::Serialize for NetworkId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for NetworkId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        u64::deserialize(deserializer).map(|id| NetworkId(id))
+    }
+}
+
 /// Connection and disconnection events in the server.
 #[derive(Debug)]
 #[cfg_attr(feature = "bevy", derive(bevy_ecs::prelude::Event))]

--- a/renet/src/server.rs
+++ b/renet/src/server.rs
@@ -1,67 +1,11 @@
 use crate::error::{ClientNotFound, DisconnectReason};
 use crate::packet::Payload;
 use crate::remote_connection::{ConnectionConfig, NetworkInfo, RenetClient};
+use crate::ClientId;
 use std::collections::{HashMap, VecDeque};
-use std::fmt::Display;
 use std::time::Duration;
 
 use bytes::Bytes;
-
-/// A unique identifier to identify clients and the server
-///
-/// The server typically has an id of 0
-#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
-pub struct ClientId(u64);
-
-impl ClientId {
-    /// Creates a [`ClientId`] from a raw 64 bit value.
-    pub fn from_raw(value: u64) -> Self {
-        Self(value)
-    }
-
-    /// Returns the raw 64 bit value of the [`ClientId`]
-    pub fn raw(&self) -> u64 {
-        self.0
-    }
-}
-
-impl From<u64> for ClientId {
-    fn from(value: u64) -> Self {
-        Self::from_raw(value)
-    }
-}
-
-impl From<&u64> for ClientId {
-    fn from(value: &u64) -> Self {
-        Self::from_raw(*value)
-    }
-}
-
-impl Display for ClientId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-#[cfg(feature = "serde")]
-impl serde::Serialize for ClientId {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        self.0.serialize(serializer)
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<'de> serde::Deserialize<'de> for ClientId {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        u64::deserialize(deserializer).map(ClientId::from_raw)
-    }
-}
 
 /// Connection and disconnection events in the server.
 #[derive(Debug)]

--- a/renet/src/server.rs
+++ b/renet/src/server.rs
@@ -2,22 +2,54 @@ use crate::error::{ClientNotFound, DisconnectReason};
 use crate::packet::Payload;
 use crate::remote_connection::{ConnectionConfig, NetworkInfo, RenetClient};
 use std::collections::{HashMap, VecDeque};
+use std::fmt::Display;
 use std::time::Duration;
 
 use bytes::Bytes;
+
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
+pub struct NetworkId(u64);
+
+impl NetworkId {
+    pub fn from_raw(value: u64) -> Self {
+        Self(value)
+    }
+
+    pub fn raw(&self) -> u64 {
+        self.0
+    }
+}
+
+impl From<u64> for NetworkId {
+    fn from(value: u64) -> Self {
+        Self::from_raw(value)
+    }
+}
+
+impl From<&u64> for NetworkId {
+    fn from(value: &u64) -> Self {
+        Self::from_raw(*value)
+    }
+}
+
+impl Display for NetworkId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 /// Connection and disconnection events in the server.
 #[derive(Debug)]
 #[cfg_attr(feature = "bevy", derive(bevy_ecs::prelude::Event))]
 pub enum ServerEvent {
-    ClientConnected { client_id: u64 },
-    ClientDisconnected { client_id: u64, reason: DisconnectReason },
+    ClientConnected { client_id: NetworkId },
+    ClientDisconnected { client_id: NetworkId, reason: DisconnectReason },
 }
 
 #[derive(Debug)]
 #[cfg_attr(feature = "bevy", derive(bevy_ecs::system::Resource))]
 pub struct RenetServer {
-    connections: HashMap<u64, RenetClient>,
+    connections: HashMap<NetworkId, RenetClient>,
     connection_config: ConnectionConfig,
     events: VecDeque<ServerEvent>,
 }
@@ -35,7 +67,7 @@ impl RenetServer {
     /// <p style="background:rgba(77,220,255,0.16);padding:0.5em;">
     /// <strong>Note:</strong> This should only be called by the transport layer.
     /// </p>
-    pub fn add_connection(&mut self, client_id: u64) {
+    pub fn add_connection(&mut self, client_id: NetworkId) {
         if self.connections.contains_key(&client_id) {
             return;
         }
@@ -72,7 +104,7 @@ impl RenetServer {
     }
 
     /// Returns the disconnection reason for the client if its disconnected
-    pub fn disconnect_reason(&self, client_id: u64) -> Option<DisconnectReason> {
+    pub fn disconnect_reason(&self, client_id: NetworkId) -> Option<DisconnectReason> {
         if let Some(connection) = self.connections.get(&client_id) {
             return connection.disconnect_reason();
         }
@@ -81,7 +113,7 @@ impl RenetServer {
     }
 
     /// Returns the round-time trip for the client or 0.0 if the client is not found
-    pub fn rtt(&self, client_id: u64) -> f64 {
+    pub fn rtt(&self, client_id: NetworkId) -> f64 {
         match self.connections.get(&client_id) {
             Some(connection) => connection.rtt(),
             None => 0.0,
@@ -89,7 +121,7 @@ impl RenetServer {
     }
 
     /// Returns the packet loss for the client or 0.0 if the client is not found
-    pub fn packet_loss(&self, client_id: u64) -> f64 {
+    pub fn packet_loss(&self, client_id: NetworkId) -> f64 {
         match self.connections.get(&client_id) {
             Some(connection) => connection.packet_loss(),
             None => 0.0,
@@ -97,7 +129,7 @@ impl RenetServer {
     }
 
     /// Returns the bytes sent per seconds for the client or 0.0 if the client is not found
-    pub fn bytes_sent_per_sec(&self, client_id: u64) -> f64 {
+    pub fn bytes_sent_per_sec(&self, client_id: NetworkId) -> f64 {
         match self.connections.get(&client_id) {
             Some(connection) => connection.bytes_sent_per_sec(),
             None => 0.0,
@@ -105,7 +137,7 @@ impl RenetServer {
     }
 
     /// Returns the bytes received per seconds for the client or 0.0 if the client is not found
-    pub fn bytes_received_per_sec(&self, client_id: u64) -> f64 {
+    pub fn bytes_received_per_sec(&self, client_id: NetworkId) -> f64 {
         match self.connections.get(&client_id) {
             Some(connection) => connection.bytes_received_per_sec(),
             None => 0.0,
@@ -113,7 +145,7 @@ impl RenetServer {
     }
 
     /// Returns all network informations for the client
-    pub fn network_info(&self, client_id: u64) -> Result<NetworkInfo, ClientNotFound> {
+    pub fn network_info(&self, client_id: NetworkId) -> Result<NetworkInfo, ClientNotFound> {
         match self.connections.get(&client_id) {
             Some(connection) => Ok(connection.network_info()),
             None => Err(ClientNotFound),
@@ -125,7 +157,7 @@ impl RenetServer {
     /// <p style="background:rgba(77,220,255,0.16);padding:0.5em;">
     /// <strong>Note:</strong> This should only be called by the transport layer.
     /// </p>
-    pub fn remove_connection(&mut self, client_id: u64) {
+    pub fn remove_connection(&mut self, client_id: NetworkId) {
         if let Some(connection) = self.connections.remove(&client_id) {
             let reason = connection.disconnect_reason().unwrap_or(DisconnectReason::Transport);
             self.events.push_back(ServerEvent::ClientDisconnected { client_id, reason });
@@ -133,7 +165,7 @@ impl RenetServer {
     }
 
     /// Disconnects a client, it does nothing if the client does not exits.
-    pub fn disconnect(&mut self, client_id: u64) {
+    pub fn disconnect(&mut self, client_id: NetworkId) {
         if let Some(connection) = self.connections.get_mut(&client_id) {
             if !connection.is_disconnected() {
                 connection.disconnect_reason = Some(DisconnectReason::DisconnectedByServer);
@@ -160,7 +192,7 @@ impl RenetServer {
     }
 
     /// Send a message to all clients, except the specified one, over a channel.
-    pub fn broadcast_message_except<I: Into<u8>, B: Into<Bytes>>(&mut self, except_id: u64, channel_id: I, message: B) {
+    pub fn broadcast_message_except<I: Into<u8>, B: Into<Bytes>>(&mut self, except_id: NetworkId, channel_id: I, message: B) {
         let channel_id = channel_id.into();
         let message = message.into();
         for (connection_id, connection) in self.connections.iter_mut() {
@@ -174,7 +206,7 @@ impl RenetServer {
 
     /// Returns the available memory in bytes of a channel for the given client.
     /// Returns 0 if the client is not found.
-    pub fn channel_available_memory<I: Into<u8>>(&self, client_id: u64, channel_id: I) -> usize {
+    pub fn channel_available_memory<I: Into<u8>>(&self, client_id: NetworkId, channel_id: I) -> usize {
         match self.connections.get(&client_id) {
             Some(connection) => connection.channel_available_memory(channel_id),
             None => 0,
@@ -183,7 +215,7 @@ impl RenetServer {
 
     /// Checks if can send a message with the given size in bytes over a channel for the given client.
     /// Returns false if the client is not found.
-    pub fn can_send_message<I: Into<u8>>(&self, client_id: u64, channel_id: I, size_bytes: usize) -> bool {
+    pub fn can_send_message<I: Into<u8>>(&self, client_id: NetworkId, channel_id: I, size_bytes: usize) -> bool {
         match self.connections.get(&client_id) {
             Some(connection) => connection.can_send_message(channel_id, size_bytes),
             None => false,
@@ -191,7 +223,7 @@ impl RenetServer {
     }
 
     /// Send a message to a client over a channel.
-    pub fn send_message<I: Into<u8>, B: Into<Bytes>>(&mut self, client_id: u64, channel_id: I, message: B) {
+    pub fn send_message<I: Into<u8>, B: Into<Bytes>>(&mut self, client_id: NetworkId, channel_id: I, message: B) {
         match self.connections.get_mut(&client_id) {
             Some(connection) => connection.send_message(channel_id, message),
             None => log::error!("Tried to send a message to invalid client {:?}", client_id),
@@ -199,7 +231,7 @@ impl RenetServer {
     }
 
     /// Receive a message from a client over a channel.
-    pub fn receive_message<I: Into<u8>>(&mut self, client_id: u64, channel_id: I) -> Option<Bytes> {
+    pub fn receive_message<I: Into<u8>>(&mut self, client_id: NetworkId, channel_id: I) -> Option<Bytes> {
         if let Some(connection) = self.connections.get_mut(&client_id) {
             return connection.receive_message(channel_id);
         }
@@ -207,22 +239,22 @@ impl RenetServer {
     }
 
     /// Return ids for all connected clients (iterator)
-    pub fn clients_id_iter(&self) -> impl Iterator<Item = u64> + '_ {
+    pub fn clients_id_iter(&self) -> impl Iterator<Item = NetworkId> + '_ {
         self.connections.iter().filter(|(_, c)| !c.is_disconnected()).map(|(id, _)| *id)
     }
 
     /// Return ids for all connected clients
-    pub fn clients_id(&self) -> Vec<u64> {
+    pub fn clients_id(&self) -> Vec<NetworkId> {
         self.clients_id_iter().collect()
     }
 
     /// Return ids for all disconnected clients (iterator)
-    pub fn disconnections_id_iter(&self) -> impl Iterator<Item = u64> + '_ {
+    pub fn disconnections_id_iter(&self) -> impl Iterator<Item = NetworkId> + '_ {
         self.connections.iter().filter(|(_, c)| c.is_disconnected()).map(|(id, _)| *id)
     }
 
     /// Return ids for all disconnected clients
-    pub fn disconnections_id(&self) -> Vec<u64> {
+    pub fn disconnections_id(&self) -> Vec<NetworkId> {
         self.disconnections_id_iter().collect()
     }
 
@@ -231,7 +263,7 @@ impl RenetServer {
         self.connections.iter().filter(|(_, c)| c.is_disconnected()).count()
     }
 
-    pub fn is_connected(&self, client_id: u64) -> bool {
+    pub fn is_connected(&self, client_id: NetworkId) -> bool {
         if let Some(connection) = self.connections.get(&client_id) {
             return !connection.is_disconnected();
         }
@@ -251,7 +283,7 @@ impl RenetServer {
     /// <p style="background:rgba(77,220,255,0.16);padding:0.5em;">
     /// <strong>Note:</strong> This should only be called by the transport layer.
     /// </p>
-    pub fn get_packets_to_send(&mut self, client_id: u64) -> Result<Vec<Payload>, ClientNotFound> {
+    pub fn get_packets_to_send(&mut self, client_id: NetworkId) -> Result<Vec<Payload>, ClientNotFound> {
         match self.connections.get_mut(&client_id) {
             Some(connection) => Ok(connection.get_packets_to_send()),
             None => Err(ClientNotFound),
@@ -262,7 +294,7 @@ impl RenetServer {
     /// <p style="background:rgba(77,220,255,0.16);padding:0.5em;">
     /// <strong>Note:</strong> This should only be called by the transport layer.
     /// </p>
-    pub fn process_packet_from(&mut self, payload: &[u8], client_id: u64) -> Result<(), ClientNotFound> {
+    pub fn process_packet_from(&mut self, payload: &[u8], client_id: NetworkId) -> Result<(), ClientNotFound> {
         match self.connections.get_mut(&client_id) {
             Some(connection) => {
                 connection.process_packet(payload);

--- a/renet/src/server.rs
+++ b/renet/src/server.rs
@@ -7,14 +7,19 @@ use std::time::Duration;
 
 use bytes::Bytes;
 
+/// A unique identifier to identify clients and the server
+///
+/// The server typically has an id of 0
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
 pub struct NetworkId(u64);
 
 impl NetworkId {
+    /// Creates a [`NetworkId`] from a raw 64 bit value.
     pub fn from_raw(value: u64) -> Self {
         Self(value)
     }
 
+    /// Returns the raw 64 bit value of the [`NetworkId`]
     pub fn raw(&self) -> u64 {
         self.0
     }

--- a/renet/src/transport/server.rs
+++ b/renet/src/transport/server.rs
@@ -68,8 +68,8 @@ impl NetcodeServerTransport {
 
     /// Returns the duration since the connected client last received a packet.
     /// Usefull to detect users that are timing out.
-    pub fn time_since_last_received_packet(&self, client_id: u64) -> Option<Duration> {
-        self.netcode_server.time_since_last_received_packet(client_id)
+    pub fn time_since_last_received_packet(&self, client_id: NetworkId) -> Option<Duration> {
+        self.netcode_server.time_since_last_received_packet(client_id.raw())
     }
 
     /// Advances the transport by the duration, and receive packets from the network.

--- a/renet/src/transport/server.rs
+++ b/renet/src/transport/server.rs
@@ -6,7 +6,8 @@ use std::{
 
 use renetcode::{NetcodeServer, ServerConfig, ServerResult, NETCODE_MAX_PACKET_BYTES, NETCODE_USER_DATA_BYTES};
 
-use crate::server::{ClientId, RenetServer};
+use crate::ClientId;
+use crate::RenetServer;
 
 use super::NetcodeTransportError;
 
@@ -137,7 +138,8 @@ fn handle_server_result(server_result: ServerResult, socket: &UdpSocket, reliabl
             send_packet(payload, addr);
         }
         ServerResult::Payload { client_id, payload } => {
-            if let Err(e) = reliable_server.process_packet_from(payload, client_id.into()) {
+            let client_id = ClientId::from_raw(client_id);
+            if let Err(e) = reliable_server.process_packet_from(payload, client_id) {
                 log::error!("Error while processing payload for {}: {}", client_id, e);
             }
         }
@@ -151,7 +153,7 @@ fn handle_server_result(server_result: ServerResult, socket: &UdpSocket, reliabl
             send_packet(payload, addr);
         }
         ServerResult::ClientDisconnected { client_id, addr, payload } => {
-            reliable_server.remove_connection(client_id.into());
+            reliable_server.remove_connection(ClientId::from_raw(client_id));
             if let Some(payload) = payload {
                 send_packet(payload, addr);
             }

--- a/renet/src/transport/server.rs
+++ b/renet/src/transport/server.rs
@@ -6,7 +6,7 @@ use std::{
 
 use renetcode::{NetcodeServer, ServerConfig, ServerResult, NETCODE_MAX_PACKET_BYTES, NETCODE_USER_DATA_BYTES};
 
-use crate::server::{NetworkId, RenetServer};
+use crate::server::{ClientId, RenetServer};
 
 use super::NetcodeTransportError;
 
@@ -47,12 +47,12 @@ impl NetcodeServerTransport {
     }
 
     /// Returns the user data for client if connected.
-    pub fn user_data(&self, client_id: NetworkId) -> Option<[u8; NETCODE_USER_DATA_BYTES]> {
+    pub fn user_data(&self, client_id: ClientId) -> Option<[u8; NETCODE_USER_DATA_BYTES]> {
         self.netcode_server.user_data(client_id.raw())
     }
 
     /// Returns the client address if connected.
-    pub fn client_addr(&self, client_id: NetworkId) -> Option<SocketAddr> {
+    pub fn client_addr(&self, client_id: ClientId) -> Option<SocketAddr> {
         self.netcode_server.client_addr(client_id.raw())
     }
 
@@ -68,7 +68,7 @@ impl NetcodeServerTransport {
 
     /// Returns the duration since the connected client last received a packet.
     /// Usefull to detect users that are timing out.
-    pub fn time_since_last_received_packet(&self, client_id: NetworkId) -> Option<Duration> {
+    pub fn time_since_last_received_packet(&self, client_id: ClientId) -> Option<Duration> {
         self.netcode_server.time_since_last_received_packet(client_id.raw())
     }
 
@@ -147,7 +147,7 @@ fn handle_server_result(server_result: ServerResult, socket: &UdpSocket, reliabl
             addr,
             payload,
         } => {
-            reliable_server.add_connection(NetworkId::from_raw(client_id));
+            reliable_server.add_connection(ClientId::from_raw(client_id));
             send_packet(payload, addr);
         }
         ServerResult::ClientDisconnected { client_id, addr, payload } => {

--- a/renet/tests/lib.rs
+++ b/renet/tests/lib.rs
@@ -1,5 +1,5 @@
 use bytes::Bytes;
-use renet::{ConnectionConfig, DefaultChannel, RenetClient, RenetServer};
+use renet::{ConnectionConfig, DefaultChannel, NetworkId, RenetClient, RenetServer};
 
 pub fn init_log() {
     let _ = env_logger::builder().is_test(true).try_init();
@@ -11,7 +11,7 @@ fn test_remote_connection_reliable_channel() {
     let mut server = RenetServer::new(ConnectionConfig::default());
     let mut client = RenetClient::new(ConnectionConfig::default());
 
-    let client_id = 0u64;
+    let client_id = NetworkId::from_raw(0);
     server.add_connection(client_id);
 
     for _ in 0..200 {

--- a/renet/tests/lib.rs
+++ b/renet/tests/lib.rs
@@ -1,5 +1,5 @@
 use bytes::Bytes;
-use renet::{ConnectionConfig, DefaultChannel, NetworkId, RenetClient, RenetServer};
+use renet::{ClientId, ConnectionConfig, DefaultChannel, RenetClient, RenetServer};
 
 pub fn init_log() {
     let _ = env_logger::builder().is_test(true).try_init();
@@ -11,7 +11,7 @@ fn test_remote_connection_reliable_channel() {
     let mut server = RenetServer::new(ConnectionConfig::default());
     let mut client = RenetClient::new(ConnectionConfig::default());
 
-    let client_id = NetworkId::from_raw(0);
+    let client_id = ClientId::from_raw(0);
     server.add_connection(client_id);
 
     for _ in 0..200 {

--- a/renet_visualizer/src/lib.rs
+++ b/renet_visualizer/src/lib.rs
@@ -5,7 +5,7 @@ use egui::{
     pos2, remap, vec2, Color32, Rect, Rgba, RichText, Rounding, Sense, Shape, Stroke, TextStyle, Vec2, WidgetText,
 };
 
-use renet::{NetworkId, NetworkInfo, RenetServer};
+use renet::{ClientId, NetworkInfo, RenetServer};
 
 use circular_buffer::CircularBuffer;
 
@@ -33,8 +33,8 @@ pub struct RenetClientVisualizer<const N: usize> {
 #[cfg_attr(feature = "bevy", derive(bevy_ecs::system::Resource))]
 pub struct RenetServerVisualizer<const N: usize> {
     show_all_clients: bool,
-    selected_client: Option<NetworkId>,
-    clients: HashMap<NetworkId, RenetClientVisualizer<N>>,
+    selected_client: Option<ClientId>,
+    clients: HashMap<ClientId, RenetClientVisualizer<N>>,
     style: RenetVisualizerStyle,
 }
 
@@ -213,7 +213,7 @@ impl<const N: usize> RenetServerVisualizer<N> {
     ///     }
     /// }
     /// ```
-    pub fn add_client(&mut self, client_id: NetworkId) {
+    pub fn add_client(&mut self, client_id: ClientId) {
         self.clients.insert(client_id, RenetClientVisualizer::new(self.style.clone()));
     }
 
@@ -236,11 +236,11 @@ impl<const N: usize> RenetServerVisualizer<N> {
     ///     }
     /// }
     /// ```
-    pub fn remove_client(&mut self, client_id: NetworkId) {
+    pub fn remove_client(&mut self, client_id: ClientId) {
         self.clients.remove(&client_id);
     }
 
-    fn add_network_info(&mut self, client_id: NetworkId, network_info: NetworkInfo) {
+    fn add_network_info(&mut self, client_id: ClientId, network_info: NetworkInfo) {
         if let Some(client) = self.clients.get_mut(&client_id) {
             client.add_network_info(network_info);
         }
@@ -268,7 +268,7 @@ impl<const N: usize> RenetServerVisualizer<N> {
     }
 
     /// Draw all metrics without a window or layout for the specified client.
-    pub fn draw_client_metrics(&self, client_id: NetworkId, ui: &mut egui::Ui) {
+    pub fn draw_client_metrics(&self, client_id: ClientId, ui: &mut egui::Ui) {
         if let Some(client) = self.clients.get(&client_id) {
             client.draw_all(ui);
         }

--- a/renet_visualizer/src/lib.rs
+++ b/renet_visualizer/src/lib.rs
@@ -5,7 +5,7 @@ use egui::{
     pos2, remap, vec2, Color32, Rect, Rgba, RichText, Rounding, Sense, Shape, Stroke, TextStyle, Vec2, WidgetText,
 };
 
-use renet::{NetworkInfo, RenetServer};
+use renet::{NetworkId, NetworkInfo, RenetServer};
 
 use circular_buffer::CircularBuffer;
 
@@ -33,8 +33,8 @@ pub struct RenetClientVisualizer<const N: usize> {
 #[cfg_attr(feature = "bevy", derive(bevy_ecs::system::Resource))]
 pub struct RenetServerVisualizer<const N: usize> {
     show_all_clients: bool,
-    selected_client: Option<u64>,
-    clients: HashMap<u64, RenetClientVisualizer<N>>,
+    selected_client: Option<NetworkId>,
+    clients: HashMap<NetworkId, RenetClientVisualizer<N>>,
     style: RenetVisualizerStyle,
 }
 
@@ -213,7 +213,7 @@ impl<const N: usize> RenetServerVisualizer<N> {
     ///     }
     /// }
     /// ```
-    pub fn add_client(&mut self, client_id: u64) {
+    pub fn add_client(&mut self, client_id: NetworkId) {
         self.clients.insert(client_id, RenetClientVisualizer::new(self.style.clone()));
     }
 
@@ -236,11 +236,11 @@ impl<const N: usize> RenetServerVisualizer<N> {
     ///     }
     /// }
     /// ```
-    pub fn remove_client(&mut self, client_id: u64) {
+    pub fn remove_client(&mut self, client_id: NetworkId) {
         self.clients.remove(&client_id);
     }
 
-    fn add_network_info(&mut self, client_id: u64, network_info: NetworkInfo) {
+    fn add_network_info(&mut self, client_id: NetworkId, network_info: NetworkInfo) {
         if let Some(client) = self.clients.get_mut(&client_id) {
             client.add_network_info(network_info);
         }
@@ -268,7 +268,7 @@ impl<const N: usize> RenetServerVisualizer<N> {
     }
 
     /// Draw all metrics without a window or layout for the specified client.
-    pub fn draw_client_metrics(&self, client_id: u64, ui: &mut egui::Ui) {
+    pub fn draw_client_metrics(&self, client_id: NetworkId, ui: &mut egui::Ui) {
         if let Some(client) = self.clients.get(&client_id) {
             client.draw_all(ui);
         }


### PR DESCRIPTION
fixes: #41 

I had a rough time solving the merge conflicts from my last pull request, so I just forced my fork to upstream, that seems to have automatically closed my previous PR. 

# Changes

- Added the `ClientId` type in renet/src/server.rs
- renetcode should not be changed in this PR
- `renew` now has a `serde` feature, which adds `Serialization` and `Deserialization` impls for `ClientId` when enabled.

I tried to take all the feedback from the previous PR, and apply it to this one
