### PR TITLE
Add Transport layer based on memory channels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,6 @@ members = [
     "bevy_renet",
     "renet_visualizer",
     "renet_steam",
+    "renet_channel",
 ]
 resolver = "2"

--- a/bevy_renet/Cargo.toml
+++ b/bevy_renet/Cargo.toml
@@ -15,6 +15,7 @@ default = ["transport"]
 serde = ["renet/serde"]
 transport = ["renet/transport"]
 steam = ["renet_steam"]
+channel = ["renet_channel"]
 
 [[example]]
 name = "simple"
@@ -24,6 +25,7 @@ required-features = ["serde", "transport"]
 bevy = {version = "0.12", default-features = false}
 renet = {path = "../renet", version = "0.0.14", features = ["bevy"]}
 renet_steam = { path = "../renet_steam", version = "0.0.1", features = [ "bevy" ], optional = true }
+renet_channel = { path = "../renet_channel", version = "0.0.1", features = [ "bevy" ], optional = true }
 
 [dev-dependencies]
 bevy = {version = "0.12", default-features = false, features = ["bevy_core_pipeline", "bevy_render", "bevy_asset", "bevy_pbr", "x11", "tonemapping_luts", "ktx2", "zstd"]}

--- a/bevy_renet/Cargo.toml
+++ b/bevy_renet/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.0.10"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["transport", "channel"]
+default = ["transport"]
 serde = ["renet/serde"]
 transport = ["renet/transport"]
 steam = ["renet_steam"]

--- a/bevy_renet/Cargo.toml
+++ b/bevy_renet/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.0.10"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["transport"]
+default = ["transport", "channel"]
 serde = ["renet/serde"]
 transport = ["renet/transport"]
 steam = ["renet_steam"]

--- a/bevy_renet/src/channel.rs
+++ b/bevy_renet/src/channel.rs
@@ -74,46 +74,9 @@ impl ChannelClientPlugin {
 
     fn disconnect_on_exit(mut transport: ResMut<ChannelClientTransport>, mut client: ResMut<RenetClient>, exit: EventReader<AppExit>) {
         if !exit.is_empty() {
+            client.disconnect();
             transport.disconnect(&mut client);
         }
-    }
-}
-
-pub fn client_connected() -> impl FnMut(Option<Res<ChannelClientTransport>>) -> bool {
-    |transport| match transport {
-        Some(transport) => transport.is_connected(),
-        None => false,
-    }
-}
-
-pub fn client_disconnected() -> impl FnMut(Option<Res<ChannelClientTransport>>) -> bool {
-    |transport| match transport {
-        Some(transport) => !transport.is_connected(),
-        None => true,
-    }
-}
-
-pub fn client_connecting() -> impl FnMut(Option<Res<ChannelClientTransport>>) -> bool {
-    |_transport| false
-}
-
-pub fn client_just_connected() -> impl FnMut(Local<bool>, Option<Res<ChannelClientTransport>>) -> bool {
-    |mut last_connected: Local<bool>, transport| {
-        let connected = transport.map(|transport| transport.is_connected()).unwrap_or(false);
-
-        let just_connected = !*last_connected && connected;
-        *last_connected = connected;
-        just_connected
-    }
-}
-
-pub fn client_just_disconnected() -> impl FnMut(Local<bool>, Option<Res<ChannelClientTransport>>) -> bool {
-    |mut last_connected: Local<bool>, transport| {
-        let disconnected = transport.map(|transport| transport.is_connected()).unwrap_or(true);
-
-        let just_disconnected = *last_connected && disconnected;
-        *last_connected = !disconnected;
-        just_disconnected
     }
 }
 

--- a/bevy_renet/src/channel.rs
+++ b/bevy_renet/src/channel.rs
@@ -1,0 +1,342 @@
+use bevy::app::AppExit;
+use bevy::prelude::*;
+use renet::{RenetClient, RenetServer};
+use renet_channel::{ChannelClientTransport, ChannelServerTransport};
+
+use crate::{RenetClientPlugin, RenetServerPlugin};
+
+pub struct ChannelServerPlugin;
+
+pub struct ChannelClientPlugin;
+
+impl Plugin for ChannelServerPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            PreUpdate,
+            Self::update_system
+                .run_if(resource_exists::<RenetServer>())
+                .run_if(resource_exists::<ChannelServerTransport>())
+                .after(RenetServerPlugin::update_system),
+        )
+        .add_systems(
+            PostUpdate,
+            (Self::send_packets, Self::disconnect_on_exit)
+                .run_if(resource_exists::<RenetServer>())
+                .run_if(resource_exists::<ChannelServerTransport>()),
+        );
+    }
+}
+
+impl ChannelServerPlugin {
+    pub fn update_system(mut transport: ResMut<ChannelServerTransport>, mut server: ResMut<RenetServer>) {
+        transport.update(&mut server);
+    }
+
+    pub fn send_packets(mut transport: ResMut<ChannelServerTransport>, mut server: ResMut<RenetServer>) {
+        transport.send_packets(&mut server);
+    }
+
+    fn disconnect_on_exit(exit: EventReader<AppExit>, mut transport: ResMut<ChannelServerTransport>, mut server: ResMut<RenetServer>) {
+        if !exit.is_empty() {
+            transport.disconnect_all(&mut server);
+        }
+    }
+}
+
+impl Plugin for ChannelClientPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            PreUpdate,
+            Self::update_system
+                .run_if(resource_exists::<RenetClient>())
+                .run_if(resource_exists::<ChannelClientTransport>())
+                .after(RenetClientPlugin::update_system),
+        )
+        .add_systems(
+            PostUpdate,
+            (Self::send_packets, Self::disconnect_on_exit)
+                .run_if(resource_exists::<RenetClient>())
+                .run_if(resource_exists::<ChannelClientTransport>()),
+        );
+    }
+}
+
+impl ChannelClientPlugin {
+    pub fn update_system(mut transport: ResMut<ChannelClientTransport>, mut client: ResMut<RenetClient>) {
+        transport.update(&mut client);
+    }
+
+    pub fn send_packets(mut transport: ResMut<ChannelClientTransport>, mut client: ResMut<RenetClient>) {
+        transport.send_packets(&mut client);
+    }
+
+    fn disconnect_on_exit(mut transport: ResMut<ChannelClientTransport>, mut client: ResMut<RenetClient>, exit: EventReader<AppExit>) {
+        if !exit.is_empty() {
+            transport.disconnect(&mut client);
+        }
+    }
+}
+
+pub fn client_connected() -> impl FnMut(Option<Res<ChannelClientTransport>>) -> bool {
+    |transport| match transport {
+        Some(transport) => transport.is_connected(),
+        None => false,
+    }
+}
+
+pub fn client_disconnected() -> impl FnMut(Option<Res<ChannelClientTransport>>) -> bool {
+    |transport| match transport {
+        Some(transport) => !transport.is_connected(),
+        None => true,
+    }
+}
+
+pub fn client_connecting() -> impl FnMut(Option<Res<ChannelClientTransport>>) -> bool {
+    |_transport| false
+}
+
+pub fn client_just_connected() -> impl FnMut(Local<bool>, Option<Res<ChannelClientTransport>>) -> bool {
+    |mut last_connected: Local<bool>, transport| {
+        let connected = transport.map(|transport| transport.is_connected()).unwrap_or(false);
+
+        let just_connected = !*last_connected && connected;
+        *last_connected = connected;
+        just_connected
+    }
+}
+
+pub fn client_just_disconnected() -> impl FnMut(Local<bool>, Option<Res<ChannelClientTransport>>) -> bool {
+    |mut last_connected: Local<bool>, transport| {
+        let disconnected = transport.map(|transport| transport.is_connected()).unwrap_or(true);
+
+        let just_disconnected = *last_connected && disconnected;
+        *last_connected = !disconnected;
+        just_disconnected
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::renet::{ClientId, ConnectionConfig, DefaultChannel};
+
+    use super::*;
+
+    #[derive(Debug, Default, Resource, PartialEq, Eq, Deref, DerefMut)]
+    pub struct ServerReceived(Vec<(u64, Vec<u8>)>);
+
+    #[derive(Debug, Default, Resource, PartialEq, Eq, Deref, DerefMut)]
+    pub struct ClientReceived(Vec<Vec<u8>>);
+
+    fn client_received(client: &App) -> Vec<Vec<u8>> {
+        client.world.resource::<ClientReceived>().0.clone()
+    }
+
+    fn server_received(server: &App) -> Vec<(u64, Vec<u8>)> {
+        let mut received = server.world.resource::<ServerReceived>().0.clone();
+        received.sort_by_key(|&(client_id, _)| client_id);
+        received
+    }
+
+    fn create_server_app() -> App {
+        let server_transport = ChannelServerTransport::default();
+        let renet_server = RenetServer::new(ConnectionConfig::default());
+
+        let mut server = App::new();
+        server
+            .add_plugins((MinimalPlugins, RenetServerPlugin, ChannelServerPlugin))
+            .insert_resource(renet_server)
+            .insert_resource(server_transport)
+            .init_resource::<ServerReceived>()
+            .add_systems(Update, |mut server: ResMut<RenetServer>, mut received: ResMut<ServerReceived>| {
+                for client_id in server.clients_id() {
+                    while let Some(packet) = server.receive_message(client_id, DefaultChannel::ReliableOrdered) {
+                        received.push((client_id.raw(), packet.to_vec()));
+                    }
+                }
+            });
+
+        server
+    }
+
+    fn create_client_app(server: &mut App) -> App {
+        let mut server_transport = server.world.resource_mut::<ChannelServerTransport>();
+        let client_transport = server_transport.create_client();
+        let renet_client = RenetClient::new(ConnectionConfig::default());
+
+        let mut client = App::new();
+        client
+            .add_plugins((MinimalPlugins, RenetClientPlugin, ChannelClientPlugin))
+            .insert_resource(renet_client)
+            .insert_resource(client_transport)
+            .init_resource::<ClientReceived>()
+            .add_systems(Update, |mut client: ResMut<RenetClient>, mut received: ResMut<ClientReceived>| {
+                while let Some(packet) = client.receive_message(DefaultChannel::ReliableOrdered) {
+                    received.push(packet.to_vec());
+                }
+            });
+
+        client
+    }
+
+    #[test]
+    fn simple_transport() {
+        let mut server = create_server_app();
+        let mut client = create_client_app(&mut server);
+
+        assert!(client.world.resource::<ChannelClientTransport>().is_connected());
+
+        server.add_systems(Update, |mut server: ResMut<RenetServer>| {
+            server.broadcast_message(DefaultChannel::ReliableOrdered, vec![1]);
+        });
+        server.update();
+        client.update();
+
+        assert_eq!(client_received(&client), [[1]]);
+        assert_eq!(server_received(&server), []);
+    }
+
+    #[test]
+    fn multiple_messages() {
+        let mut server = create_server_app();
+        let mut client = create_client_app(&mut server);
+
+        server.add_systems(Update, |mut server: ResMut<RenetServer>| {
+            server.broadcast_message(DefaultChannel::ReliableOrdered, vec![1, 2]);
+            server.broadcast_message(DefaultChannel::ReliableOrdered, vec![3]);
+        });
+        server.update();
+        server.update();
+        client.update();
+
+        assert_eq!(client_received(&client), [vec![1, 2], vec![3], vec![1, 2], vec![3]]);
+        assert_eq!(server_received(&server), []);
+
+        server.update();
+        client.update();
+
+        assert_eq!(
+            client_received(&client),
+            [vec![1, 2], vec![3], vec![1, 2], vec![3], vec![1, 2], vec![3]]
+        );
+        assert_eq!(server_received(&server), []);
+    }
+
+    #[test]
+    fn both_directions() {
+        let mut server = create_server_app();
+        let mut client = create_client_app(&mut server);
+
+        server.add_systems(Update, |mut server: ResMut<RenetServer>| {
+            server.broadcast_message(DefaultChannel::ReliableOrdered, vec![1]);
+        });
+        client.add_systems(Update, |mut client: ResMut<RenetClient>| {
+            client.send_message(DefaultChannel::ReliableOrdered, vec![2]);
+        });
+        server.update();
+        client.update();
+
+        assert_eq!(client_received(&client), [[1]]);
+        assert_eq!(server_received(&server), []);
+
+        server.update();
+
+        assert_eq!(client_received(&client), [[1]]);
+        assert_eq!(server_received(&server), [(0, vec![2])]);
+    }
+
+    #[test]
+    fn multiple_clients() {
+        let mut server = create_server_app();
+        let mut client1 = create_client_app(&mut server);
+        let mut client2 = create_client_app(&mut server);
+        let mut client3 = create_client_app(&mut server);
+
+        server.add_systems(Update, |mut server: ResMut<RenetServer>| {
+            server.broadcast_message(DefaultChannel::ReliableOrdered, vec![0]);
+        });
+        client1.add_systems(Update, |mut client: ResMut<RenetClient>| {
+            client.send_message(DefaultChannel::ReliableOrdered, vec![1]);
+        });
+        client2.add_systems(Update, |mut client: ResMut<RenetClient>| {
+            client.send_message(DefaultChannel::ReliableOrdered, vec![2]);
+        });
+        client3.add_systems(Update, |mut client: ResMut<RenetClient>| {
+            client.send_message(DefaultChannel::ReliableOrdered, vec![3]);
+        });
+
+        server.update();
+        client1.update();
+        client2.update();
+        client3.update();
+
+        assert_eq!(client_received(&client1), [[0]]);
+        assert_eq!(client_received(&client2), [[0]]);
+        assert_eq!(client_received(&client3), [[0]]);
+        assert_eq!(server_received(&server), []);
+
+        server.update();
+
+        assert_eq!(client_received(&client1), [[0]]);
+        assert_eq!(client_received(&client2), [[0]]);
+        assert_eq!(client_received(&client3), [[0]]);
+        assert_eq!(server_received(&server), [(0, vec![1]), (1, vec![2]), (2, vec![3])]);
+    }
+
+    #[test]
+    fn disconnect_client() {
+        let mut server = create_server_app();
+        let mut client = create_client_app(&mut server);
+
+        server.update();
+        assert_eq!(server.world.resource::<RenetServer>().clients_id(), vec![ClientId::from_raw(0)]);
+        assert!(client.world.resource::<ChannelClientTransport>().is_connected());
+
+        client.world.send_event(AppExit);
+        client.update();
+        server.update();
+
+        assert!(client.world.resource::<RenetClient>().is_disconnected());
+        assert!(!client.world.resource::<ChannelClientTransport>().is_connected());
+
+        assert!(server.world.resource::<RenetServer>().clients_id().is_empty());
+    }
+
+    #[test]
+    fn disconnect_server() {
+        let mut server = create_server_app();
+        let mut client = create_client_app(&mut server);
+
+        fn send_msg(mut server: ResMut<RenetServer>) {
+            server.broadcast_message(DefaultChannel::ReliableOrdered, vec![0]);
+        }
+        server.add_systems(Update, send_msg.run_if(run_once()));
+
+        server.update();
+
+        assert_eq!(server.world.resource::<RenetServer>().clients_id(), [ClientId::from_raw(0)]);
+        assert!(client.world.resource::<ChannelClientTransport>().is_connected());
+
+        server.world.send_event(AppExit);
+        server.update();
+        client.update();
+
+        assert!(server.world.resource::<RenetServer>().clients_id().is_empty());
+
+        assert!(client_received(&client).is_empty());
+
+        assert!(client.world.resource::<RenetClient>().is_disconnected());
+        assert!(!client.world.resource::<ChannelClientTransport>().is_connected());
+    }
+
+    #[test]
+    fn no_transport() {
+        let mut server = create_server_app();
+        let mut client = create_client_app(&mut server);
+
+        server.world.remove_resource::<ChannelServerTransport>();
+        client.world.remove_resource::<ChannelClientTransport>();
+
+        server.update();
+        client.update();
+    }
+}

--- a/bevy_renet/src/channel.rs
+++ b/bevy_renet/src/channel.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 use renet::{RenetClient, RenetServer};
 use renet_channel::{ChannelClientTransport, ChannelServerTransport};
 
-use crate::{RenetClientPlugin, RenetServerPlugin};
+use crate::{RenetClientPlugin, RenetReceive, RenetSend, RenetServerPlugin};
 
 pub struct ChannelServerPlugin;
 
@@ -14,13 +14,14 @@ impl Plugin for ChannelServerPlugin {
         app.add_systems(
             PreUpdate,
             Self::update_system
+                .in_set(RenetReceive)
                 .run_if(resource_exists::<RenetServer>())
                 .run_if(resource_exists::<ChannelServerTransport>())
                 .after(RenetServerPlugin::update_system),
         )
         .add_systems(
             PostUpdate,
-            (Self::send_packets, Self::disconnect_on_exit)
+            (Self::send_packets.in_set(RenetSend), Self::disconnect_on_exit)
                 .run_if(resource_exists::<RenetServer>())
                 .run_if(resource_exists::<ChannelServerTransport>()),
         );
@@ -48,13 +49,14 @@ impl Plugin for ChannelClientPlugin {
         app.add_systems(
             PreUpdate,
             Self::update_system
+                .in_set(RenetReceive)
                 .run_if(resource_exists::<RenetClient>())
                 .run_if(resource_exists::<ChannelClientTransport>())
                 .after(RenetClientPlugin::update_system),
         )
         .add_systems(
             PostUpdate,
-            (Self::send_packets, Self::disconnect_on_exit)
+            (Self::send_packets.in_set(RenetSend), Self::disconnect_on_exit)
                 .run_if(resource_exists::<RenetClient>())
                 .run_if(resource_exists::<ChannelClientTransport>()),
         );

--- a/bevy_renet/src/lib.rs
+++ b/bevy_renet/src/lib.rs
@@ -10,6 +10,9 @@ pub mod transport;
 #[cfg(feature = "steam")]
 pub mod steam;
 
+#[cfg(feature = "channel")]
+pub mod channel;
+
 /// This system set is where all transports receive messages
 ///
 /// If you want to ensure data has arrived in the [`RenetClient`] or [`RenetServer`], then schedule your

--- a/renet_channel/Cargo.toml
+++ b/renet_channel/Cargo.toml
@@ -15,6 +15,6 @@ bevy = ["dep:bevy_ecs", "dep:bevy_utils"]
 
 [dependencies]
 renet = { path = "../renet" }
-bevy_ecs = { version = "0.11", optional = true }
-bevy_utils = { version = "0.11", optional = true }
+bevy_ecs = { version = "0.12", optional = true }
+bevy_utils = { version = "0.12", optional = true }
 crossbeam = "0.8.2"

--- a/renet_channel/Cargo.toml
+++ b/renet_channel/Cargo.toml
@@ -1,6 +1,11 @@
 [package]
 name = "renet_channel"
 version = "0.0.1"
+keywords = ["gamedev", "networking", "transport"]
+description = "channel transport for the renet crate: Server/Client network library for multiplayer games"
+repository = "https://github.com/lucaspoffo/renet"
+license = "MIT OR Apache-2.0"
+readme = "README.md"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -12,3 +17,4 @@ bevy = ["dep:bevy_ecs", "dep:bevy_utils"]
 renet = { path = "../renet" }
 bevy_ecs = { version = "0.11", optional = true }
 bevy_utils = { version = "0.11", optional = true }
+crossbeam = "0.8.2"

--- a/renet_channel/Cargo.toml
+++ b/renet_channel/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "renet_channel"
+version = "0.0.1"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[features]
+bevy = ["dep:bevy_ecs", "dep:bevy_utils"]
+
+[dependencies]
+renet = { path = "../renet" }
+bevy_ecs = { version = "0.11", optional = true }
+bevy_utils = { version = "0.11", optional = true }

--- a/renet_channel/README.md
+++ b/renet_channel/README.md
@@ -1,0 +1,3 @@
+# Renet Channel
+
+Transport layer for renet using crossbeam mpmc

--- a/renet_channel/src/client.rs
+++ b/renet_channel/src/client.rs
@@ -1,0 +1,56 @@
+use std::sync::mpsc::{Receiver, Sender, TryRecvError};
+
+use renet::RenetClient;
+
+use crate::Connection;
+
+#[cfg_attr(feature = "bevy", derive(bevy_ecs::system::Resource))]
+pub struct ChannelClientTransport {
+    connection: Option<Connection>,
+}
+
+impl ChannelClientTransport {
+    pub(crate) fn new(receiver: Receiver<Vec<u8>>, sender: Sender<Vec<u8>>) -> Self {
+        Self {
+            connection: Some(Connection::new(sender, receiver)),
+        }
+    }
+
+    pub fn update(&mut self, client: &mut RenetClient) {
+        let Some(ref mut connection) = self.connection else { return };
+
+        loop {
+            match connection.receiver().try_recv() {
+                Ok(packet) => {
+                    client.process_packet(&packet);
+                    continue;
+                }
+                Err(TryRecvError::Empty) => (),
+                Err(TryRecvError::Disconnected) => self.disconnect(client),
+            }
+            break;
+        }
+    }
+
+    pub fn send_packets(&mut self, client: &mut RenetClient) {
+        let packets = client.get_packets_to_send();
+
+        for packet in packets {
+            let Some(ref mut connection) = self.connection else { continue };
+
+            if connection.sender().send(packet).is_err() {
+                self.disconnect(client);
+                break;
+            }
+        }
+    }
+
+    pub fn disconnect(&mut self, client: &mut RenetClient) {
+        client.disconnect();
+        self.connection.take();
+    }
+
+    pub fn is_connected(&self) -> bool {
+        self.connection.is_some()
+    }
+}

--- a/renet_channel/src/client.rs
+++ b/renet_channel/src/client.rs
@@ -1,5 +1,5 @@
 use crossbeam::channel::{Receiver, Sender, TryRecvError};
-use renet::{ClientId, RenetClient, DisconnectReason};
+use renet::{ClientId, DisconnectReason, RenetClient};
 
 use crate::Connection;
 
@@ -31,7 +31,7 @@ impl ChannelClientTransport {
                 Err(TryRecvError::Disconnected) => {
                     client.disconnect_due_to_transport();
                     self.disconnect(client)
-                },
+                }
             }
             break;
         }

--- a/renet_channel/src/client.rs
+++ b/renet_channel/src/client.rs
@@ -1,5 +1,5 @@
 use crossbeam::channel::{Receiver, Sender, TryRecvError};
-use renet::{ClientId, DisconnectReason, RenetClient};
+use renet::{ClientId, RenetClient};
 
 use crate::Connection;
 

--- a/renet_channel/src/lib.rs
+++ b/renet_channel/src/lib.rs
@@ -1,21 +1,11 @@
-use std::sync::mpsc::{Receiver, Sender};
-
-#[cfg(feature = "bevy")]
-use bevy_utils::synccell::SyncCell;
-
-mod client;
-mod server;
+use crossbeam::channel::{Receiver, Sender};
 
 pub use client::ChannelClientTransport;
 pub use server::ChannelServerTransport;
 
-#[cfg(feature = "bevy")]
-struct Connection {
-    sender: SyncCell<Sender<Vec<u8>>>,
-    receiver: SyncCell<Receiver<Vec<u8>>>,
-}
+mod client;
+mod server;
 
-#[cfg(not(feature = "bevy"))]
 struct Connection {
     sender: Sender<Vec<u8>>,
     receiver: Receiver<Vec<u8>>,
@@ -23,36 +13,6 @@ struct Connection {
 
 impl Connection {
     fn new(sender: Sender<Vec<u8>>, receiver: Receiver<Vec<u8>>) -> Self {
-        #[cfg(feature = "bevy")]
-        {
-            Self {
-                sender: SyncCell::new(sender),
-                receiver: SyncCell::new(receiver),
-            }
-        }
-        #[cfg(not(feature = "bevy"))]
-        {
-            Self { sender, receiver }
-        }
-    }
-
-    #[cfg(feature = "bevy")]
-    fn receiver(&mut self) -> &mut Receiver<Vec<u8>> {
-        self.receiver.get()
-    }
-
-    #[cfg(feature = "bevy")]
-    fn sender(&mut self) -> &mut Sender<Vec<u8>> {
-        self.sender.get()
-    }
-
-    #[cfg(not(feature = "bevy"))]
-    fn receiver(&mut self) -> &mut Receiver<Vec<u8>> {
-        &mut self.receiver
-    }
-
-    #[cfg(not(feature = "bevy"))]
-    fn sender(&mut self) -> &mut Sender<Vec<u8>> {
-        &mut self.sender
+        Self { sender, receiver }
     }
 }

--- a/renet_channel/src/lib.rs
+++ b/renet_channel/src/lib.rs
@@ -1,0 +1,58 @@
+use std::sync::mpsc::{Receiver, Sender};
+
+#[cfg(feature = "bevy")]
+use bevy_utils::synccell::SyncCell;
+
+mod client;
+mod server;
+
+pub use client::ChannelClientTransport;
+pub use server::ChannelServerTransport;
+
+#[cfg(feature = "bevy")]
+struct Connection {
+    sender: SyncCell<Sender<Vec<u8>>>,
+    receiver: SyncCell<Receiver<Vec<u8>>>,
+}
+
+#[cfg(not(feature = "bevy"))]
+struct Connection {
+    sender: Sender<Vec<u8>>,
+    receiver: Receiver<Vec<u8>>,
+}
+
+impl Connection {
+    fn new(sender: Sender<Vec<u8>>, receiver: Receiver<Vec<u8>>) -> Self {
+        #[cfg(feature = "bevy")]
+        {
+            Self {
+                sender: SyncCell::new(sender),
+                receiver: SyncCell::new(receiver),
+            }
+        }
+        #[cfg(not(feature = "bevy"))]
+        {
+            Self { sender, receiver }
+        }
+    }
+
+    #[cfg(feature = "bevy")]
+    fn receiver(&mut self) -> &mut Receiver<Vec<u8>> {
+        self.receiver.get()
+    }
+
+    #[cfg(feature = "bevy")]
+    fn sender(&mut self) -> &mut Sender<Vec<u8>> {
+        self.sender.get()
+    }
+
+    #[cfg(not(feature = "bevy"))]
+    fn receiver(&mut self) -> &mut Receiver<Vec<u8>> {
+        &mut self.receiver
+    }
+
+    #[cfg(not(feature = "bevy"))]
+    fn sender(&mut self) -> &mut Sender<Vec<u8>> {
+        &mut self.sender
+    }
+}

--- a/renet_channel/src/server.rs
+++ b/renet_channel/src/server.rs
@@ -27,6 +27,20 @@ impl ChannelServerTransport {
         ChannelClientTransport::new(client_id, receive_from_server, send_to_server)
     }
 
+    pub fn create_client_with_id(&mut self, client_id: ClientId) -> Option<ChannelClientTransport> {
+        if self.connections.contains_key(&client_id) {
+            return None;
+        }
+
+        let (send_to_client, receive_from_server) = unbounded::<Vec<u8>>();
+        let (send_to_server, receive_from_client) = unbounded::<Vec<u8>>();
+
+        let connection = Connection::new(send_to_client, receive_from_client);
+        self.connections.insert(client_id, connection);
+
+        Some(ChannelClientTransport::new(client_id, receive_from_server, send_to_server))
+    }
+
     pub fn update(&mut self, server: &mut RenetServer) {
         for (&client_id, connection) in self.connections.iter_mut() {
             server.add_connection(client_id);

--- a/renet_channel/src/server.rs
+++ b/renet_channel/src/server.rs
@@ -1,0 +1,70 @@
+use std::collections::HashMap;
+use std::mem;
+use std::sync::mpsc::{self, TryRecvError};
+
+use renet::{ClientId, RenetServer};
+
+use crate::client::ChannelClientTransport;
+use crate::Connection;
+
+#[cfg_attr(feature = "bevy", derive(bevy_ecs::system::Resource))]
+#[derive(Default)]
+pub struct ChannelServerTransport {
+    connections: HashMap<ClientId, Connection>,
+    next_client_id: u64,
+}
+
+impl ChannelServerTransport {
+    pub fn create_client(&mut self) -> ChannelClientTransport {
+        let (send_to_client, receive_from_server) = mpsc::channel::<Vec<u8>>();
+        let (send_to_server, receive_from_client) = mpsc::channel::<Vec<u8>>();
+
+        let client_id = ClientId::from_raw(self.next_client_id);
+        self.next_client_id += 1;
+
+        let connection = Connection::new(send_to_client, receive_from_client);
+        self.connections.insert(client_id, connection);
+
+        ChannelClientTransport::new(receive_from_server, send_to_server)
+    }
+
+    pub fn update(&mut self, server: &mut RenetServer) {
+        for (&client_id, connection) in self.connections.iter_mut() {
+            server.add_connection(client_id);
+
+            match connection.receiver().try_recv() {
+                Ok(packet) => server.process_packet_from(&packet, client_id).unwrap(),
+                Err(TryRecvError::Empty) => (),
+                Err(TryRecvError::Disconnected) => {
+                    self.disconnect_client(client_id, server);
+                    break;
+                }
+            }
+        }
+    }
+
+    pub fn send_packets(&mut self, server: &mut RenetServer) {
+        for client_id in server.clients_id() {
+            let connection = self.connections.get_mut(&client_id).unwrap();
+
+            let packets = server.get_packets_to_send(client_id).unwrap();
+
+            for packet in packets {
+                if connection.sender().send(packet).is_err() {
+                    self.disconnect_client(client_id, server);
+                    break;
+                }
+            }
+        }
+    }
+
+    pub fn disconnect_client(&mut self, client_id: ClientId, server: &mut RenetServer) {
+        self.connections.remove(&client_id);
+        server.disconnect(client_id);
+    }
+
+    pub fn disconnect_all(&mut self, server: &mut RenetServer) {
+        mem::take(&mut self.connections);
+        server.disconnect_all();
+    }
+}


### PR DESCRIPTION
### Overview

This pull request implements a transport layer based on the stdlib mpsc channel.
This allows the renet server and clients to communicate efficiently within a single program.
This is especially useful for testing networking code, where you want to be able to guarantee that messages arrive immediately, without having to go through the OS network layer.
This should also hopefully allow benchmarks to be more consistent.

It also allows more efficient emulation of a locally hosted server that actually runs within the same binary.

### Notes

As this can only be used within the same program, I decided to only expose a way to create new clients from an already existing server. I think this method simplifies the API significantly, and doesn't diminish the ergonomics in the scenarios I am able of thinking of.

I'm not very happy with the current state of the `Connection` struct, so any advice on that would be very welcome. The problem arises from Sender/Receiver being `!Sync`, but bevy resources need to be `Sync`. Bevy therefore provides a `SyncCell` which can turn `Send` types into `Sync` types by only allowing access through a `&mut SyncCell<T>`. However if this is used outside bevy, then `SyncCell` is not available. Thus in the current implementation the Transports are `!Sync` when used standalone.
The only good solution I can think of to remedy this would be to copy a barebones version of Bevy's SyncCell and use that. This isn't a great solution, but this struct isn't public outside of `renet_channel`, so it might be okay.

I also wasn't sure what to do about the example, since this layer only runs within the same process you can't make a proper echo example, so I just added a whole bunch of tests.