### PR TITLE
Allow application code to be transport agnostic

### DIFF
--- a/bevy_renet/examples/simple.rs
+++ b/bevy_renet/examples/simple.rs
@@ -5,7 +5,7 @@ use bevy_renet::{
         ConnectionConfig, DefaultChannel, RenetClient, RenetServer, ServerEvent,
     },
     transport::{NetcodeClientPlugin, NetcodeServerPlugin},
-    RenetClientPlugin, RenetServerPlugin,
+    RenetClientPlugin, RenetServerPlugin, client_connected,
 };
 use renet::{
     transport::{NetcodeClientTransport, NetcodeServerTransport, NetcodeTransportError},
@@ -118,7 +118,7 @@ fn main() {
 
         app.add_systems(
             Update,
-            (player_input, client_send_input, client_sync_players).run_if(bevy_renet::transport::client_connected()),
+            (player_input, client_send_input, client_sync_players).run_if(client_connected()),
         );
     }
 

--- a/bevy_renet/src/lib.rs
+++ b/bevy_renet/src/lib.rs
@@ -10,6 +10,24 @@ pub mod transport;
 #[cfg(feature = "steam")]
 pub mod steam;
 
+/// This system set is where all transports receive messages
+///
+/// If you want to ensure data has arrived in the [`RenetClient`] or [`RenetServer`], then schedule your
+/// system after this set.
+///
+/// This system set runs in PreUpdate
+#[derive(Debug, SystemSet, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct RenetReceive;
+
+/// This system set is where all transports send messages
+///
+/// If you want to ensure your packets have been registered by the [`RenetClient`] or [`RenetServer`], then
+/// schedule your system before this set.
+///
+/// This system set runs in PostUpdate
+#[derive(Debug, SystemSet, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct RenetSend;
+
 pub struct RenetServerPlugin;
 
 pub struct RenetClientPlugin;
@@ -40,5 +58,46 @@ impl Plugin for RenetClientPlugin {
 impl RenetClientPlugin {
     pub fn update_system(mut client: ResMut<RenetClient>, time: Res<Time>) {
         client.update(time.delta());
+    }
+}
+
+pub fn client_connected() -> impl FnMut(Option<Res<RenetClient>>) -> bool {
+    |client| match client {
+        Some(client) => client.is_connected(),
+        None => false,
+    }
+}
+
+pub fn client_disconnected() -> impl FnMut(Option<Res<RenetClient>>) -> bool {
+    |client| match client {
+        Some(client) => client.is_disconnected(),
+        None => true,
+    }
+}
+
+pub fn client_connecting() -> impl FnMut(Option<Res<RenetClient>>) -> bool {
+    |client| match client {
+        Some(client) => client.is_connecting(),
+        None => false,
+    }
+}
+
+pub fn client_just_connected() -> impl FnMut(Local<bool>, Option<Res<RenetClient>>) -> bool {
+    |mut last_connected: Local<bool>, client| {
+        let connected = client.map(|client| client.is_connected()).unwrap_or(false);
+
+        let just_connected = !*last_connected && connected;
+        *last_connected = connected;
+        just_connected
+    }
+}
+
+pub fn client_just_disconnected() -> impl FnMut(Local<bool>, Option<Res<RenetClient>>) -> bool {
+    |mut last_connected: Local<bool>, client| {
+        let disconnected = client.map(|client| client.is_disconnected()).unwrap_or(true);
+
+        let just_disconnected = *last_connected && disconnected;
+        *last_connected = !disconnected;
+        just_disconnected
     }
 }

--- a/bevy_renet/src/lib.rs
+++ b/bevy_renet/src/lib.rs
@@ -15,7 +15,7 @@ pub mod steam;
 /// If you want to ensure data has arrived in the [`RenetClient`] or [`RenetServer`], then schedule your
 /// system after this set.
 ///
-/// This system set runs in PreUpdate
+/// This system set runs in PreUpdate.
 #[derive(Debug, SystemSet, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct RenetReceive;
 
@@ -24,7 +24,7 @@ pub struct RenetReceive;
 /// If you want to ensure your packets have been registered by the [`RenetClient`] or [`RenetServer`], then
 /// schedule your system before this set.
 ///
-/// This system set runs in PostUpdate
+/// This system set runs in PostUpdate.
 #[derive(Debug, SystemSet, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct RenetSend;
 

--- a/bevy_renet/src/transport.rs
+++ b/bevy_renet/src/transport.rs
@@ -5,7 +5,7 @@ use renet::{
 
 use bevy::{app::AppExit, prelude::*};
 
-use crate::{RenetClientPlugin, RenetServerPlugin};
+use crate::{RenetClientPlugin, RenetReceive, RenetSend, RenetServerPlugin};
 
 pub struct NetcodeServerPlugin;
 
@@ -18,6 +18,7 @@ impl Plugin for NetcodeServerPlugin {
         app.add_systems(
             PreUpdate,
             Self::update_system
+                .in_set(RenetReceive)
                 .run_if(resource_exists::<NetcodeServerTransport>())
                 .run_if(resource_exists::<RenetServer>())
                 .after(RenetServerPlugin::update_system),
@@ -25,7 +26,7 @@ impl Plugin for NetcodeServerPlugin {
 
         app.add_systems(
             PostUpdate,
-            (Self::send_packets, Self::disconnect_on_exit)
+            (Self::send_packets.in_set(RenetSend), Self::disconnect_on_exit)
                 .run_if(resource_exists::<NetcodeServerTransport>())
                 .run_if(resource_exists::<RenetServer>()),
         );
@@ -33,7 +34,7 @@ impl Plugin for NetcodeServerPlugin {
 }
 
 impl NetcodeServerPlugin {
-    pub fn update_system(
+    fn update_system(
         mut transport: ResMut<NetcodeServerTransport>,
         mut server: ResMut<RenetServer>,
         time: Res<Time>,
@@ -44,7 +45,7 @@ impl NetcodeServerPlugin {
         }
     }
 
-    pub fn send_packets(mut transport: ResMut<NetcodeServerTransport>, mut server: ResMut<RenetServer>) {
+    fn send_packets(mut transport: ResMut<NetcodeServerTransport>, mut server: ResMut<RenetServer>) {
         transport.send_packets(&mut server);
     }
 
@@ -98,49 +99,8 @@ impl NetcodeClientPlugin {
     }
 
     fn disconnect_on_exit(exit: EventReader<AppExit>, mut transport: ResMut<NetcodeClientTransport>) {
-        if !exit.is_empty() && !transport.is_disconnected() {
+        if !exit.is_empty() {
             transport.disconnect();
         }
-    }
-}
-
-pub fn client_connected() -> impl FnMut(Option<Res<NetcodeClientTransport>>) -> bool {
-    |transport| match transport {
-        Some(transport) => transport.is_connected(),
-        None => false,
-    }
-}
-
-pub fn client_disconnected() -> impl FnMut(Option<Res<NetcodeClientTransport>>) -> bool {
-    |transport| match transport {
-        Some(transport) => transport.is_disconnected(),
-        None => true,
-    }
-}
-
-pub fn client_connecting() -> impl FnMut(Option<Res<NetcodeClientTransport>>) -> bool {
-    |transport| match transport {
-        Some(transport) => transport.is_connecting(),
-        None => false,
-    }
-}
-
-pub fn client_just_connected() -> impl FnMut(Local<bool>, Option<Res<NetcodeClientTransport>>) -> bool {
-    |mut last_connected: Local<bool>, transport| {
-        let connected = transport.map(|transport| transport.is_connected()).unwrap_or(false);
-
-        let just_connected = !*last_connected && connected;
-        *last_connected = connected;
-        just_connected
-    }
-}
-
-pub fn client_just_disconnected() -> impl FnMut(Local<bool>, Option<Res<NetcodeClientTransport>>) -> bool {
-    |mut last_connected: Local<bool>, transport| {
-        let disconnected = transport.map(|transport| transport.is_disconnected()).unwrap_or(true);
-
-        let just_disconnected = *last_connected && disconnected;
-        *last_connected = !disconnected;
-        just_disconnected
     }
 }

--- a/demo_bevy/src/bin/client.rs
+++ b/demo_bevy/src/bin/client.rs
@@ -7,6 +7,7 @@ use bevy::{
 };
 use bevy_egui::{EguiContexts, EguiPlugin};
 use bevy_renet::{
+    client_connected,
     renet::{ClientId, RenetClient},
     RenetClientPlugin,
 };
@@ -46,7 +47,7 @@ fn add_netcode_network(app: &mut App) {
     use std::{net::UdpSocket, time::SystemTime};
 
     app.add_plugins(bevy_renet::transport::NetcodeClientPlugin);
-    app.configure_set(Update, Connected.run_if(bevy_renet::transport::client_connected()));
+    app.configure_set(Update, Connected.run_if(client_connected()));
 
     let client = RenetClient::new(connection_config());
 
@@ -98,7 +99,7 @@ fn add_steam_network(app: &mut App) {
     app.insert_resource(transport);
     app.insert_resource(CurrentClientId(steam_client.user().steam_id().raw()));
 
-    app.configure_set(Update, Connected.run_if(bevy_renet::steam::client_connected()));
+    app.configure_set(Update, Connected.run_if(client_connected()));
 
     app.insert_non_send_resource(single);
     fn steam_callbacks(client: NonSend<SingleClient>) {

--- a/demo_chat/src/client.rs
+++ b/demo_chat/src/client.rs
@@ -57,7 +57,7 @@ impl ChatApp {
             AppState::MainScreen => {
                 draw_main_screen(&mut self.ui_state, &mut self.state, ctx);
             }
-            AppState::ClientChat { transport, .. } if transport.is_connecting() => draw_loader(ctx),
+            AppState::ClientChat { client, .. } if client.is_connecting() => draw_loader(ctx),
             AppState::ClientChat { usernames, .. } => {
                 let usernames = usernames.clone();
                 draw_chat(&mut self.ui_state, &mut self.state, usernames, ctx);

--- a/renet/examples/echo.rs
+++ b/renet/examples/echo.rs
@@ -153,7 +153,7 @@ fn client(server_addr: SocketAddr, username: Username) {
         client.update(duration);
         transport.update(duration, &mut client).unwrap();
 
-        if transport.is_connected() {
+        if client.is_connected() {
             match stdin_channel.try_recv() {
                 Ok(text) => client.send_message(DefaultChannel::ReliableOrdered, text.as_bytes().to_vec()),
                 Err(TryRecvError::Empty) => {}

--- a/renet/src/error.rs
+++ b/renet/src/error.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use crate::packet::SerializationError;
 
-/// Possibles reasons for a disconnection.
+/// Possible reasons for a disconnection.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum DisconnectReason {
     /// Connection was terminated by the transport layer

--- a/renet/src/lib.rs
+++ b/renet/src/lib.rs
@@ -10,7 +10,7 @@ pub mod transport;
 
 pub use channel::{ChannelConfig, DefaultChannel, SendType};
 pub use error::{ChannelError, ClientNotFound, DisconnectReason};
-pub use remote_connection::{ConnectionConfig, NetworkInfo, RenetClient};
+pub use remote_connection::{ConnectionConfig, RenetConnectionStatus, NetworkInfo, RenetClient};
 pub use server::{RenetServer, ServerEvent};
 
 pub use bytes::Bytes;

--- a/renet/src/remote_connection.rs
+++ b/renet/src/remote_connection.rs
@@ -70,7 +70,7 @@ pub struct NetworkInfo {
     pub bytes_received_per_second: f64,
 }
 
-/// The connection status of a [`RenetClient`]
+/// The connection status of a [`RenetClient`].
 #[derive(Debug)]
 pub enum RenetConnectionStatus {
     Connected,
@@ -252,7 +252,9 @@ impl RenetClient {
         }
     }
 
-    /// Set the client connection status to connecting.
+    /// Set the client connection status to connected.
+    ///
+    /// Does nothing if the client is disconnected. A disconnected client must be reconstructed.
     ///
     /// <p style="background:rgba(77,220,255,0.16);padding:0.5em;">
     /// <strong>Note:</strong> This should only be called by the transport layer.
@@ -265,6 +267,8 @@ impl RenetClient {
 
     /// Set the client connection status to connecting.
     ///
+    /// Does nothing if the client is disconnected. A disconnected client must be reconstructed.
+    ///
     /// <p style="background:rgba(77,220,255,0.16);padding:0.5em;">
     /// <strong>Note:</strong> This should only be called by the transport layer.
     /// </p>
@@ -275,12 +279,14 @@ impl RenetClient {
     }
 
     /// Disconnect the client.
+    ///
     /// If the client is already disconnected, it does nothing.
     pub fn disconnect(&mut self) {
         self.disconnect_with_reason(DisconnectReason::DisconnectedByClient);
     }
 
     /// Disconnect the client because an error occurred in the transport layer.
+    ///
     /// If the client is already disconnected, it does nothing.
     /// <p style="background:rgba(77,220,255,0.16);padding:0.5em;">
     /// <strong>Note:</strong> This should only be called by the transport layer.

--- a/renet/src/remote_connection.rs
+++ b/renet/src/remote_connection.rs
@@ -222,21 +222,21 @@ impl RenetClient {
         }
     }
 
-    /// Returns if the client is connected.
+    /// Returns whether the client is connected.
     ///
     #[inline]
     pub fn is_connected(&self) -> bool {
         matches!(self.connection_status, RenetConnectionStatus::Connected)
     }
 
-    /// Returns if the client is connecting.
+    /// Returns whether the client is connecting.
     ///
     #[inline]
     pub fn is_connecting(&self) -> bool {
         matches!(self.connection_status, RenetConnectionStatus::Connecting)
     }
 
-    /// Returns if the client is disconnected.
+    /// Returns whether the client is disconnected.
     ///
     #[inline]
     pub fn is_disconnected(&self) -> bool {

--- a/renet/src/remote_connection.rs
+++ b/renet/src/remote_connection.rs
@@ -223,21 +223,18 @@ impl RenetClient {
     }
 
     /// Returns whether the client is connected.
-    ///
     #[inline]
     pub fn is_connected(&self) -> bool {
         matches!(self.connection_status, RenetConnectionStatus::Connected)
     }
 
     /// Returns whether the client is connecting.
-    ///
     #[inline]
     pub fn is_connecting(&self) -> bool {
         matches!(self.connection_status, RenetConnectionStatus::Connecting)
     }
 
     /// Returns whether the client is disconnected.
-    ///
     #[inline]
     pub fn is_disconnected(&self) -> bool {
         matches!(self.connection_status, RenetConnectionStatus::Disconnected { .. })

--- a/renet/src/remote_connection.rs
+++ b/renet/src/remote_connection.rs
@@ -70,6 +70,14 @@ pub struct NetworkInfo {
     pub bytes_received_per_second: f64,
 }
 
+/// The connection status of a [`RenetClient`]
+#[derive(Debug)]
+pub enum RenetConnectionStatus {
+    Connected,
+    Connecting,
+    Disconnected { reason: DisconnectReason },
+}
+
 #[derive(Debug)]
 #[cfg_attr(feature = "bevy", derive(bevy_ecs::system::Resource))]
 pub struct RenetClient {
@@ -84,7 +92,7 @@ pub struct RenetClient {
     receive_reliable_channels: HashMap<u8, ReceiveChannelReliable>,
     stats: ConnectionStats,
     available_bytes_per_tick: u64,
-    pub(crate) disconnect_reason: Option<DisconnectReason>,
+    connection_status: RenetConnectionStatus,
     rtt: f64,
 }
 
@@ -180,7 +188,7 @@ impl RenetClient {
             stats: ConnectionStats::new(),
             rtt: 0.0,
             available_bytes_per_tick,
-            disconnect_reason: None,
+            connection_status: RenetConnectionStatus::Connecting,
         }
     }
 
@@ -214,28 +222,62 @@ impl RenetClient {
         }
     }
 
+    /// Returns if the client is connected.
+    ///
+    #[inline]
+    pub fn is_connected(&self) -> bool {
+        matches!(self.connection_status, RenetConnectionStatus::Connected)
+    }
+
+    /// Returns if the client is connecting.
+    ///
+    #[inline]
+    pub fn is_connecting(&self) -> bool {
+        matches!(self.connection_status, RenetConnectionStatus::Connecting)
+    }
+
     /// Returns if the client is disconnected.
     ///
-    /// Note: to check if a client is connecting you need to use the transport layer [NetcodeClientTransport::is_connecting][crate::transport::NetcodeClientTransport::is_connecting].
-    /// You can't use `!client.is_disconnected()` for that.
     #[inline]
     pub fn is_disconnected(&self) -> bool {
-        self.disconnect_reason.is_some()
+        matches!(self.connection_status, RenetConnectionStatus::Disconnected { .. })
     }
 
     /// Returns the disconneect reason if the client is disconnected.
     pub fn disconnect_reason(&self) -> Option<DisconnectReason> {
-        self.disconnect_reason
+        if let RenetConnectionStatus::Disconnected { reason } = self.connection_status {
+            Some(reason)
+        } else {
+            None
+        }
+    }
+
+    /// Set the client connection status to connecting.
+    ///
+    /// <p style="background:rgba(77,220,255,0.16);padding:0.5em;">
+    /// <strong>Note:</strong> This should only be called by the transport layer.
+    /// </p>
+    pub fn set_connected(&mut self) {
+        if !self.is_disconnected() {
+            self.connection_status = RenetConnectionStatus::Connected;
+        }
+    }
+
+    /// Set the client connection status to connecting.
+    ///
+    /// <p style="background:rgba(77,220,255,0.16);padding:0.5em;">
+    /// <strong>Note:</strong> This should only be called by the transport layer.
+    /// </p>
+    pub fn set_connecting(&mut self) {
+        if !self.is_disconnected() {
+            self.connection_status = RenetConnectionStatus::Connecting;
+        }
     }
 
     /// Disconnect the client.
     /// If the client is already disconnected, it does nothing.
     pub fn disconnect(&mut self) {
-        if self.disconnect_reason.is_some() {
-            return;
-        }
-
-        self.disconnect_reason = Some(DisconnectReason::DisconnectedByClient);
+        self.disconnect_with_reason(DisconnectReason::DisconnectedByClient);
     }
 
     /// Disconnect the client because an error occurred in the transport layer.
@@ -244,11 +286,7 @@ impl RenetClient {
     /// <strong>Note:</strong> This should only be called by the transport layer.
     /// </p>
     pub fn disconnect_due_to_transport(&mut self) {
-        if self.disconnect_reason.is_some() {
-            return;
-        }
-
-        self.disconnect_reason = Some(DisconnectReason::Transport);
+        self.disconnect_with_reason(DisconnectReason::Transport);
     }
 
     /// Returns the available memory in bytes for the given channel.
@@ -284,7 +322,7 @@ impl RenetClient {
         let channel_id = channel_id.into();
         if let Some(reliable_channel) = self.send_reliable_channels.get_mut(&channel_id) {
             if let Err(error) = reliable_channel.send_message(message.into()) {
-                self.disconnect_reason = Some(DisconnectReason::SendChannelError { channel_id, error });
+                self.disconnect_with_reason(DisconnectReason::SendChannelError { channel_id, error });
             }
         } else if let Some(unreliable_channel) = self.send_unreliable_channels.get_mut(&channel_id) {
             unreliable_channel.send_message(message.into());
@@ -350,7 +388,7 @@ impl RenetClient {
         let mut octets = octets::Octets::with_slice(packet);
         let packet = match Packet::from_bytes(&mut octets) {
             Err(err) => {
-                self.disconnect_reason = Some(DisconnectReason::PacketDeserialization(err));
+                self.disconnect_with_reason(DisconnectReason::PacketDeserialization(err));
                 return;
             }
             Ok(packet) => packet,
@@ -361,20 +399,20 @@ impl RenetClient {
         match packet {
             Packet::SmallReliable { channel_id, messages, .. } => {
                 let Some(channel) = self.receive_reliable_channels.get_mut(&channel_id) else {
-                    self.disconnect_reason = Some(DisconnectReason::ReceivedInvalidChannelId(channel_id));
+                    self.disconnect_with_reason(DisconnectReason::ReceivedInvalidChannelId(channel_id));
                     return;
                 };
 
                 for (message_id, message) in messages {
                     if let Err(error) = channel.process_message(message, message_id) {
-                        self.disconnect_reason = Some(DisconnectReason::ReceiveChannelError { channel_id, error });
+                        self.disconnect_with_reason(DisconnectReason::ReceiveChannelError { channel_id, error });
                         return;
                     }
                 }
             }
             Packet::SmallUnreliable { channel_id, messages, .. } => {
                 let Some(channel) = self.receive_unreliable_channels.get_mut(&channel_id) else {
-                    self.disconnect_reason = Some(DisconnectReason::ReceivedInvalidChannelId(channel_id));
+                    self.disconnect_with_reason(DisconnectReason::ReceivedInvalidChannelId(channel_id));
                     return;
                 };
 
@@ -384,22 +422,22 @@ impl RenetClient {
             }
             Packet::ReliableSlice { channel_id, slice, .. } => {
                 let Some(channel) = self.receive_reliable_channels.get_mut(&channel_id) else {
-                    self.disconnect_reason = Some(DisconnectReason::ReceivedInvalidChannelId(channel_id));
+                    self.disconnect_with_reason(DisconnectReason::ReceivedInvalidChannelId(channel_id));
                     return;
                 };
 
                 if let Err(error) = channel.process_slice(slice) {
-                    self.disconnect_reason = Some(DisconnectReason::ReceiveChannelError { channel_id, error });
+                    self.disconnect_with_reason(DisconnectReason::ReceiveChannelError { channel_id, error });
                 }
             }
             Packet::UnreliableSlice { channel_id, slice, .. } => {
                 let Some(channel) = self.receive_unreliable_channels.get_mut(&channel_id) else {
-                    self.disconnect_reason = Some(DisconnectReason::ReceivedInvalidChannelId(channel_id));
+                    self.disconnect_with_reason(DisconnectReason::ReceivedInvalidChannelId(channel_id));
                     return;
                 };
 
                 if let Err(error) = channel.process_slice(slice, self.current_time) {
-                    self.disconnect_reason = Some(DisconnectReason::ReceiveChannelError { channel_id, error });
+                    self.disconnect_with_reason(DisconnectReason::ReceiveChannelError { channel_id, error });
                 }
             }
             Packet::Ack { ack_ranges, .. } => {
@@ -557,7 +595,7 @@ impl RenetClient {
             let mut oct = OctetsMut::with_slice(&mut buffer);
             let len = match packet.to_bytes(&mut oct) {
                 Err(err) => {
-                    self.disconnect_reason = Some(DisconnectReason::PacketSerialization(err));
+                    self.disconnect_with_reason(DisconnectReason::PacketSerialization(err));
                     return vec![];
                 }
                 Ok(len) => len,
@@ -643,6 +681,12 @@ impl RenetClient {
             }
 
             return;
+        }
+    }
+
+    pub(crate) fn disconnect_with_reason(&mut self, reason: DisconnectReason) {
+        if !self.is_disconnected() {
+            self.connection_status = RenetConnectionStatus::Disconnected { reason };
         }
     }
 }

--- a/renet/src/server.rs
+++ b/renet/src/server.rs
@@ -136,18 +136,14 @@ impl RenetServer {
     /// Disconnects a client, it does nothing if the client does not exits.
     pub fn disconnect(&mut self, client_id: ClientId) {
         if let Some(connection) = self.connections.get_mut(&client_id) {
-            if !connection.is_disconnected() {
-                connection.disconnect_reason = Some(DisconnectReason::DisconnectedByServer);
-            }
+            connection.disconnect_with_reason(DisconnectReason::DisconnectedByServer)
         }
     }
 
     /// Disconnects all client.
     pub fn disconnect_all(&mut self) {
         for connection in self.connections.values_mut() {
-            if !connection.is_disconnected() {
-                connection.disconnect_reason = Some(DisconnectReason::DisconnectedByServer);
-            }
+            connection.disconnect_with_reason(DisconnectReason::DisconnectedByServer)
         }
     }
 

--- a/renet/src/server.rs
+++ b/renet/src/server.rs
@@ -133,7 +133,7 @@ impl RenetServer {
         }
     }
 
-    /// Disconnects a client, it does nothing if the client does not exits.
+    /// Disconnects a client, it does nothing if the client does not exist.
     pub fn disconnect(&mut self, client_id: ClientId) {
         if let Some(connection) = self.connections.get_mut(&client_id) {
             connection.disconnect_with_reason(DisconnectReason::DisconnectedByServer)

--- a/renet_steam/examples/echo.rs
+++ b/renet_steam/examples/echo.rs
@@ -157,7 +157,7 @@ fn run_client(steam_client: Client<ClientManager>, single: SingleClient, server_
         client.update(duration);
         transport.update(&mut client);
 
-        if transport.is_connected() {
+        if client.is_connected() {
             match stdin_channel.try_recv() {
                 Ok(text) => {
                     client.send_message(DefaultChannel::ReliableOrdered, text.as_bytes().to_vec());

--- a/renet_steam/src/client.rs
+++ b/renet_steam/src/client.rs
@@ -31,25 +31,25 @@ impl SteamClientTransport {
         })
     }
 
-    pub fn is_connected(&self) -> bool {
+    fn is_connected(&self) -> bool {
         let status = self.connection_state();
 
         status == NetworkingConnectionState::Connected
     }
 
-    pub fn is_disconnected(&self) -> bool {
+    fn is_disconnected(&self) -> bool {
         let status = self.connection_state();
         status == NetworkingConnectionState::ClosedByPeer
             || status == NetworkingConnectionState::ProblemDetectedLocally
             || status == NetworkingConnectionState::None
     }
 
-    pub fn is_connecting(&self) -> bool {
+    fn is_connecting(&self) -> bool {
         let status = self.connection_state();
         status == NetworkingConnectionState::Connecting || status == NetworkingConnectionState::FindingRoute
     }
 
-    pub fn connection_state(&self) -> NetworkingConnectionState {
+    fn connection_state(&self) -> NetworkingConnectionState {
         let connection = match &self.state {
             ConnectionState::Connected { connection } => connection,
             ConnectionState::Disconnected { .. } => {
@@ -103,9 +103,7 @@ impl SteamClientTransport {
     pub fn update(&mut self, client: &mut RenetClient) {
         if self.is_disconnected() {
             // Mark the client as disconnected if an error occured in the transport layer
-            if !client.is_disconnected() {
-                client.disconnect_due_to_transport();
-            }
+            client.disconnect_due_to_transport();
 
             if let ConnectionState::Connected { connection } = &self.state {
                 let end_reason = self
@@ -120,6 +118,12 @@ impl SteamClientTransport {
 
             return;
         };
+
+        if self.is_connected() {
+            client.set_connected();
+        } else if self.is_connecting() {
+            client.set_connecting();
+        }
 
         let ConnectionState::Connected { connection } = &mut self.state else {
             unreachable!()


### PR DESCRIPTION
This PR aims to provide ways of interacting with renet that are transport layer agnostic.
The basic additions in this PR are two bevy System Sets: RenetReceive and RenetSend.
These are the system sets where all transport layers should place their receive and send systems, allowing users to easily ensure that their systems run before/after Renet's transport layer systems run, rather than having to individually ensure that for each transport layer they care about.

The other addition in this PR is to move the Bevy run conditions from being implemented in each transport layer to making one single definition that uses RenetClient. This also means that each transport layer now has to update the RenetClient with the current state. 

I also made quite a few methods private, specifically the methods that expose the internal connection status of the transport layers and the systems that previously marked when a transport layer would receive/send data. This was primarily done to help users migrating from previous versions notice that these shouldn't be used anymore, as well as not confuse new users.
If this change isn't desired (especially the one about the transport layer connection status), then I'm happy to revert this change.

Fixes #115 