### PR TITLE
Update to bevy 0.12

### DIFF
--- a/bevy_renet/Cargo.toml
+++ b/bevy_renet/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["gamedev", "networking"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/lucaspoffo/renet"
-version = "0.0.9"
+version = "0.0.10"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -21,12 +21,12 @@ name = "simple"
 required-features = ["serde", "transport"]
 
 [dependencies]
-bevy = {version = "0.11", default-features = false}
+bevy = {version = "0.12", default-features = false}
 renet = {path = "../renet", version = "0.0.13", features = ["bevy"]}
 renet_steam = { path = "../renet_steam", version = "0.0.1", features = [ "bevy" ], optional = true }
 
 [dev-dependencies]
-bevy = {version = "0.11", default-features = false, features = ["bevy_core_pipeline", "bevy_render", "bevy_asset", "bevy_pbr", "x11", "tonemapping_luts", "ktx2", "zstd"]}
+bevy = {version = "0.12", default-features = false, features = ["bevy_core_pipeline", "bevy_render", "bevy_asset", "bevy_pbr", "x11", "tonemapping_luts", "ktx2", "zstd"]}
 bincode = "1.3.1"
 env_logger = "0.10.0"
 serde = {version = "1.0", features = ["derive"]}

--- a/bevy_renet/README.md
+++ b/bevy_renet/README.md
@@ -125,6 +125,7 @@ If you want a more complex example you can checkout the [demo_bevy](https://gith
 
 |bevy|bevy_renet|
 |---|---|
+|0.12|0.0.10|
 |0.11|0.0.9|
 |0.10|0.0.8|
 |0.9|0.0.6|

--- a/demo_bevy/Cargo.toml
+++ b/demo_bevy/Cargo.toml
@@ -15,15 +15,14 @@ transport = ["bevy_renet/transport"]
 steam = ["bevy_renet/steam", "steamworks"]
 
 [dependencies]
-bevy_rapier3d = "0.22.0"
-bevy = {version = "0.11", default-features = false, features = ["bevy_core_pipeline", "bevy_render", "bevy_asset", "bevy_pbr", "x11", "tonemapping_luts", "ktx2", "zstd"]}
+bevy_rapier3d = { git = "https://github.com/devil-ira/bevy_rapier.git", branch = "bevy-0.12" }
+bevy = { version = "0.12", default-features = false, features = ["bevy_core_pipeline", "bevy_render", "bevy_asset", "bevy_pbr", "x11", "tonemapping_luts", "ktx2", "zstd"] }
 bevy_renet = { path = "../bevy_renet", features = ["serde"] }
 serde = { version = "1.0", features = [ "derive" ] }
 bincode = "1.3.1"
-# Use version directly when egui is updated to 0.22
-bevy_egui = "0.21.0"
+bevy_egui = "0.23.0"
 renet_visualizer = { path = "../renet_visualizer", features = ["bevy"] }
-smooth-bevy-cameras = { git = "https://github.com/bonsairobo/smooth-bevy-cameras.git", rev = "ed8ba36d3b202bc87bbae963670e1b9419804cd0" }
+smooth-bevy-cameras = { git = "https://github.com/bonsairobo/smooth-bevy-cameras.git", rev = "7fa07bd18d206857a6c4702f35c76e2a09bbba83" }
 fastrand = "2.0.0"
 
 steamworks = { git = "https://github.com/Noxime/steamworks-rs", rev = "a4dfe2a", optional = true }

--- a/demo_bevy/src/bin/server.rs
+++ b/demo_bevy/src/bin/server.rs
@@ -297,7 +297,7 @@ fn despawn_projectile_system(
 }
 
 fn projectile_on_removal_system(mut server: ResMut<RenetServer>, mut removed_projectiles: RemovedComponents<Projectile>) {
-    for entity in &mut removed_projectiles {
+    for entity in removed_projectiles.read() {
         let message = ServerMessages::DespawnProjectile { entity };
         let message = bincode::serialize(&message).unwrap();
 

--- a/demo_chat/Cargo.toml
+++ b/demo_chat/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dependencies]
 renet = { path = "../renet", features = [ "transport", "serde" ] }
 renet_visualizer = { path = "../renet_visualizer" }
-eframe = "0.22"
+eframe = "0.23.0"
 serde = { version = "1.0", features = [ "derive" ] } 
 bincode = "1.3.1"
 log = { version = "0.4.11", features = [ "std" ] }

--- a/deny.toml
+++ b/deny.toml
@@ -32,7 +32,7 @@ unknown-registry = "deny"
 unknown-git = "deny"
 
 allow-git = [
-    # Used in Demo Bevy, remove when new version supports bevy 0.11
+    # Used in Demo Bevy, remove when new version supports bevy 0.12
     "https://github.com/bonsairobo/smooth-bevy-cameras.git",
     # Unreleased version for steamworks, need release with PR https://github.com/Noxime/steamworks-rs/pull/134
     "https://github.com/Noxime/steamworks-rs"

--- a/renet/Cargo.toml
+++ b/renet/Cargo.toml
@@ -17,7 +17,7 @@ transport = ["dep:renetcode"]
 serde = ["dep:serde"]
 
 [dependencies]
-bevy_ecs = { version = "0.11", optional = true }
+bevy_ecs = { version = "0.12", optional = true }
 bytes = "1.1"
 log = "0.4.17"
 octets = "0.2"

--- a/renet_steam/Cargo.toml
+++ b/renet_steam/Cargo.toml
@@ -18,7 +18,7 @@ renet = { path = "../renet" }
 # its version 0.10 but we need to use the rev because of a missing feature
 steamworks = { git = "https://github.com/Noxime/steamworks-rs", rev = "a4dfe2a" }
 log = "0.4.19"
-bevy_ecs = { version = "0.11", optional = true }
+bevy_ecs = { version = "0.12", optional = true }
 
 [dev-dependencies]
 env_logger = "0.10.0"

--- a/renet_visualizer/Cargo.toml
+++ b/renet_visualizer/Cargo.toml
@@ -14,5 +14,5 @@ bevy = ["dep:bevy_ecs"]
 
 [dependencies]
 renet = { path = "../renet", version = "0.0.13" }
-egui = "0.22"
-bevy_ecs = { version = "0.11.0", optional = true }
+egui = "0.23"
+bevy_ecs = { version = "0.12.0", optional = true }

--- a/renet_visualizer/src/lib.rs
+++ b/renet_visualizer/src/lib.rs
@@ -364,12 +364,12 @@ fn show_graph(
         let text_pos = rect.right_center() + vec2(spacing_x / 2.0, -galley.size().y / 2.);
         galley.paint_with_fallback_color(&ui.painter().with_clip_rect(outer_rect), text_pos, style.text_color);
 
-        let body = Shape::Rect(RectShape {
+        let body = Shape::Rect(RectShape::new(
             rect,
-            rounding: Rounding::none(),
-            fill: Rgba::TRANSPARENT.into(),
-            stroke: style.rectangle_stroke,
-        });
+            Rounding::ZERO,
+            Color32::TRANSPARENT,
+            style.rectangle_stroke,
+        ));
         ui.painter().add(body);
         let init_point = rect.left_bottom();
 


### PR DESCRIPTION
- Using git version of bevy_raiper until https://github.com/dimforge/bevy_rapier/pull/439 is merged
- Haven't updated changelog

To use this PR before it is merged: 
`bevy_renet = { git = "https://github.com/ostwilkens/renet.git", rev = "524a174448e021b2c3cf826ab7a4904ccf7dd777" }`
