### PR TITLE
Server event collection should go in RenetReceive system set

### DIFF
--- a/bevy_renet/src/lib.rs
+++ b/bevy_renet/src/lib.rs
@@ -39,6 +39,7 @@ impl Plugin for RenetServerPlugin {
         app.add_systems(
             PreUpdate,
             Self::emit_server_events_system
+                .in_set(RenetReceive)
                 .run_if(resource_exists::<RenetServer>())
                 .after(Self::update_system),
         );


### PR DESCRIPTION
This way systems in `PreUpdate` that run `.after(RenetReceive)` will properly see server events.