### PR TITLE
Do not run client systems when the client is disconnected

### DIFF
--- a/bevy_renet/src/lib.rs
+++ b/bevy_renet/src/lib.rs
@@ -57,7 +57,7 @@ impl RenetServerPlugin {
 
 impl Plugin for RenetClientPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(PreUpdate, Self::update_system.run_if(resource_exists::<RenetClient>));
+        app.add_systems(PreUpdate, Self::update_system.run_if(not(client_disconnected)));
     }
 }
 

--- a/bevy_renet/src/transport.rs
+++ b/bevy_renet/src/transport.rs
@@ -5,7 +5,7 @@ use renet::{
 
 use bevy::{app::AppExit, prelude::*};
 
-use crate::{RenetClientPlugin, RenetReceive, RenetSend, RenetServerPlugin};
+use crate::{client_disconnected, RenetClientPlugin, RenetReceive, RenetSend, RenetServerPlugin};
 
 pub struct NetcodeServerPlugin;
 
@@ -66,14 +66,14 @@ impl Plugin for NetcodeClientPlugin {
             Self::update_system
                 .in_set(RenetReceive)
                 .run_if(resource_exists::<NetcodeClientTransport>)
-                .run_if(resource_exists::<RenetClient>)
+                .run_if(not(client_disconnected))
                 .after(RenetClientPlugin::update_system),
         );
         app.add_systems(
             PostUpdate,
             (Self::send_packets.in_set(RenetSend), Self::disconnect_on_exit)
                 .run_if(resource_exists::<NetcodeClientTransport>)
-                .run_if(resource_exists::<RenetClient>),
+                .run_if(not(client_disconnected)),
         );
     }
 }

--- a/renet_steam/src/bevy.rs
+++ b/renet_steam/src/bevy.rs
@@ -3,7 +3,7 @@ use bevy_ecs::prelude::*;
 use renet::{RenetClient, RenetServer};
 use steamworks::SteamError;
 
-use bevy_renet::{RenetClientPlugin, RenetReceive, RenetSend, RenetServerPlugin};
+use bevy_renet::{client_disconnected, RenetClientPlugin, RenetReceive, RenetSend, RenetServerPlugin};
 
 pub use crate::{AccessPermission, SteamClientTransport, SteamServerConfig, SteamServerTransport};
 
@@ -73,14 +73,14 @@ impl Plugin for SteamClientPlugin {
             Self::update_system
                 .in_set(RenetReceive)
                 .run_if(resource_exists::<SteamClientTransport>)
-                .run_if(resource_exists::<RenetClient>)
+                .run_if(not(client_disconnected))
                 .after(RenetClientPlugin::update_system),
         );
         app.add_systems(
             PostUpdate,
             (Self::send_packets.in_set(RenetSend), Self::disconnect_on_exit)
                 .run_if(resource_exists::<SteamClientTransport>)
-                .run_if(resource_exists::<RenetClient>),
+                .run_if(not(client_disconnected)),
         );
     }
 }


### PR DESCRIPTION
Running systems for a disconnected client just spams transport errors.