### PR TITLE
Impl `Error` for `DisconnectReason`

### DIFF
--- a/renetcode/src/client.rs
+++ b/renetcode/src/client.rs
@@ -1,4 +1,4 @@
-use std::{fmt, net::SocketAddr, time::Duration};
+use std::{error::Error, fmt, net::SocketAddr, time::Duration};
 
 use crate::{
     packet::Packet, replay_protection::ReplayProtection, token::ConnectToken, NetcodeError, NETCODE_CHALLENGE_TOKEN_BYTES,
@@ -84,6 +84,8 @@ impl fmt::Display for DisconnectReason {
         }
     }
 }
+
+impl Error for DisconnectReason {}
 
 impl NetcodeClient {
     pub fn new(current_time: Duration, authentication: ClientAuthentication) -> Result<Self, NetcodeError> {


### PR DESCRIPTION
I recently abstracted all I/O in my crate (https://github.com/projectharmonia/bevy_replicon/pull/204) and noticed that `DisconnectReason` doesn't implement `Error`. I think it logically makes sense and would help me to create a more convenient abstraction around disconnect events.