### PR TITLE
Refactor RenetClient so channels are accessed more efficiently

### DIFF
--- a/renet/src/remote_connection.rs
+++ b/renet/src/remote_connection.rs
@@ -143,14 +143,8 @@ impl RenetClient {
         send_channels_config: Vec<ChannelConfig>,
         receive_channels_config: Vec<ChannelConfig>,
     ) -> Self {
-        let mut max_send_channel = 0;
-        let mut max_receive_channel = 0;
-        for channel_config in send_channels_config.iter() {
-            max_send_channel = max_send_channel.max(channel_config.channel_id);
-        }
-        for channel_config in receive_channels_config.iter() {
-            max_receive_channel = max_receive_channel.max(channel_config.channel_id);
-        }
+        let max_send_channel = send_channels_config.iter().map(|c| c.channel_id).max().unwrap_or_default();
+        let max_receive_channel = receive_channels_config.iter().map(|c| c.channel_id).max().unwrap_or_default();
 
         let mut send_channels = Vec::new();
         send_channels.resize_with(max_send_channel as usize + 1, || SendChannel::Empty);


### PR DESCRIPTION
## Problem

Currently you need a `HashMap` lookup to access channels in clients. On the server these hashmaps are accessed for *every* packet received.

## Solution

Use a `Vec` to store the channels so lookups are fast. Channels should be generated in monotonically increasing order, so in general there won't be any empty entries. Even if there are empty entries, at most 256 channels can be created, so the memory cost of bad channel assignment is not significant.

## Follow-up

- Reading packets requires a HashMap lookup for the target client. This is inefficient if a client has multiple packets, so a mutating iterator is preferable. Even better would probably be a global mutating iterator that traverses the client map.