### PR TITLE
Update lib.rs

### DIFF
--- a/renet/src/lib.rs
+++ b/renet/src/lib.rs
@@ -16,7 +16,7 @@ pub use server::{RenetServer, ServerEvent};
 pub use bytes::Bytes;
 
 /// Unique identifier for clients.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Ord, PartialOrd)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Ord, PartialOrd, Serialize, Deserialize)]
 pub struct ClientId(u64);
 
 impl ClientId {


### PR DESCRIPTION
Added requirement for ClientId to derive Serialize/Deserialize. I don't know if this will fix the issue, as serialize and deserialize may require some actual implementation. I just know that the simple.rs example will not compile with out that trait, probably due to the recent update of bevy.