### PR TITLE
Add delay for ack packets

### DIFF
--- a/renet/src/remote_connection.rs
+++ b/renet/src/remote_connection.rs
@@ -93,6 +93,8 @@ pub struct RenetClient {
     stats: ConnectionStats,
     available_bytes_per_tick: u64,
     connection_status: RenetConnectionStatus,
+    received_ack_eliciting_packet: bool,
+    start_ack_delay: Option<Duration>,
     rtt: f64,
 }
 
@@ -189,6 +191,8 @@ impl RenetClient {
             rtt: 0.0,
             available_bytes_per_tick,
             connection_status: RenetConnectionStatus::Connecting,
+            received_ack_eliciting_packet: false,
+            start_ack_delay: None,
         }
     }
 
@@ -399,6 +403,10 @@ impl RenetClient {
 
         self.add_pending_ack(packet.sequence());
 
+        if packet.is_ack_eliciting() {
+            self.received_ack_eliciting_packet = true;
+        }
+
         match packet {
             Packet::SmallReliable { channel_id, messages, .. } => {
                 let Some(channel) = self.receive_reliable_channels.get_mut(&channel_id) else {
@@ -443,7 +451,7 @@ impl RenetClient {
                     self.disconnect_with_reason(DisconnectReason::ReceiveChannelError { channel_id, error });
                 }
             }
-            Packet::Ack { ack_ranges, .. } => {
+            Packet::Ack { ack_ranges, ack_delay, .. } => {
                 // Create list with just new acks
                 // This prevents DoS from huge ack ranges
                 let mut new_acks: Vec<u64> = Vec::new();
@@ -458,11 +466,14 @@ impl RenetClient {
                     self.stats.acked_packet(sent_packet.sent_at, self.current_time);
 
                     // Update rtt
-                    let rtt = (self.current_time - sent_packet.sent_at).as_secs_f64();
-                    if self.rtt < f64::EPSILON {
-                        self.rtt = rtt;
-                    } else {
-                        self.rtt = self.rtt * 0.875 + rtt * 0.125;
+                    let rtt = self.current_time - sent_packet.sent_at;
+                    if let Some(rtt) = rtt.checked_sub(ack_delay) {
+                        let rtt = rtt.as_secs_f64();
+                        if self.rtt < f64::EPSILON {
+                            self.rtt = rtt;
+                        } else {
+                            self.rtt = self.rtt * 0.875 + rtt * 0.125;
+                        }
                     }
 
                     match sent_packet.info {
@@ -515,12 +526,23 @@ impl RenetClient {
         }
 
         if !self.pending_acks.is_empty() {
-            let ack_packet = Packet::Ack {
-                sequence: self.packet_sequence,
-                ack_ranges: self.pending_acks.clone(),
-            };
-            self.packet_sequence += 1;
-            packets.push(ack_packet);
+            let ack_delay =
+                if let Some(start_ack_delay) = self.start_ack_delay { self.current_time - start_ack_delay } else { Duration::ZERO };
+
+            const MAX_ACK_DELAY: Duration = Duration::from_millis(200);
+            if self.received_ack_eliciting_packet || ack_delay >= MAX_ACK_DELAY {
+                let ack_packet = Packet::Ack {
+                    sequence: self.packet_sequence,
+                    ack_ranges: self.pending_acks.clone(),
+                    ack_delay,
+                };
+                self.packet_sequence += 1;
+                packets.push(ack_packet);
+                self.start_ack_delay = None;
+                self.received_ack_eliciting_packet = false;
+            } else if self.start_ack_delay.is_none() {
+                self.start_ack_delay = Some(self.current_time);
+            }
         }
 
         let sent_at = self.current_time;
@@ -577,7 +599,7 @@ impl RenetClient {
                         },
                     );
                 }
-                Packet::Ack { sequence, ack_ranges } => {
+                Packet::Ack { sequence, ack_ranges, .. } => {
                     let last_range = ack_ranges.last().unwrap();
                     let largest_acked_packet = last_range.end - 1;
                     self.sent_packets.insert(


### PR DESCRIPTION
Currently, renet sends acks every update frame, this increases the bandwidth for connections.

This PR adds a delay for sending ACK packets, when receiving a reliable message this delay is ignored and the ACK is sent immediatly (so we don't delay acks for reliable messages).

This reduces the bandwidth of connections. For idle connections this seems to reduce from 2.15 kbps to 0.5 kbps (at 60 hz). If the connection is receiving reliable messages every frame this PR will not change the bandwidth since it will still send ACKs every frame.

This change will affect a bit the stats for the connection , since the values can be delaye, but at small MAX_ACK_DELAY ( 200-300ms), this shouldn't impact much.

TODO: make sure the RTT calculations is working correctly and check that the new delay field in the ACK packet cannot be wrongly used with malicious packets. 