### PR TITLE
disconnect_on_exit doesn't work in BevyRenet

### DIFF
--- a/bevy_renet/src/transport.rs
+++ b/bevy_renet/src/transport.rs
@@ -3,7 +3,7 @@ use renet::{
     RenetClient, RenetServer,
 };
 
-use bevy::{app::AppExit, prelude::*};
+use bevy::{app::AppExit, prelude::*, window::exit_on_all_closed};
 
 use crate::{RenetClientPlugin, RenetReceive, RenetSend, RenetServerPlugin};
 
@@ -27,7 +27,7 @@ impl Plugin for NetcodeServerPlugin {
 
         app.add_systems(
             PostUpdate,
-            (Self::send_packets.in_set(RenetSend), Self::disconnect_on_exit)
+            (Self::send_packets.in_set(RenetSend), Self::disconnect_on_exit.after(exit_on_all_closed))
                 .run_if(resource_exists::<NetcodeServerTransport>)
                 .run_if(resource_exists::<RenetServer>),
         );
@@ -71,7 +71,7 @@ impl Plugin for NetcodeClientPlugin {
         );
         app.add_systems(
             PostUpdate,
-            (Self::send_packets.in_set(RenetSend), Self::disconnect_on_exit)
+            (Self::send_packets.in_set(RenetSend), Self::disconnect_on_exit.after(exit_on_all_closed))
                 .run_if(resource_exists::<NetcodeClientTransport>)
                 .run_if(resource_exists::<RenetClient>),
         );


### PR DESCRIPTION
disconnect_on_exit doesn't work properly in BevyRenet. The system ran too early. The AppExit event isn't sent in time. This fixes the issue, so that the system runs after the AppExit event is sent.