### PR TITLE
Expose `set_max_clients` to transport

### DIFF
--- a/renet_netcode/src/server.rs
+++ b/renet_netcode/src/server.rs
@@ -42,6 +42,15 @@ impl NetcodeServerTransport {
         self.netcode_server.max_clients()
     }
 
+    /// Update the maximum numbers of clients that can be connected.
+    ///
+    /// Changing the `max_clients` to a lower value than the current number of connect clients
+    /// does not disconnect clients. So [`NetcodeServerTransport::connected_clients()`] can
+    /// return a higher value than [`NetcodeServerTransport::max_clients()`].
+    pub fn set_max_clients(&mut self, max_clients: usize) {
+        self.netcode_server.set_max_clients(max_clients);
+    }
+
     /// Returns current number of clients connected.
     pub fn connected_clients(&self) -> usize {
         self.netcode_server.connected_clients()

--- a/renetcode/src/server.rs
+++ b/renetcode/src/server.rs
@@ -556,8 +556,12 @@ impl NetcodeServer {
     /// Update the maximum numbers of clients that can be connected
     ///
     /// Changing the `max_clients` to a lower value than the current number of connect clients
-    /// does not disconnect clients. So [`NetcodeServer::connected_clients()`] can return a higher value than [`NetcodeServer::max_clients()`].
+    /// does not disconnect clients. So [`NetcodeServer::connected_clients()`] can return a
+    /// higher value than [`NetcodeServer::max_clients()`].
     pub fn set_max_clients(&mut self, max_clients: usize) {
+        let max_clients = max_clients.min(NETCODE_MAX_CLIENTS);
+        log::debug!("Netcode max_clients set to {}", max_clients);
+
         self.max_clients = max_clients;
     }
 


### PR DESCRIPTION
Delegates the `set_max_clients` method of `NetcodeServer` to `NetcodeServerTransport`. Note that this also modifies `NetcodeServer::set_max_clients` to pass `NETCODE_MAX_CLIENTS` for any argument greater than that value. If an error is preferred then let me know.