### PR TITLE
Updated renet to bevy 0.15

### DIFF
--- a/bevy_renet/Cargo.toml
+++ b/bevy_renet/Cargo.toml
@@ -20,15 +20,15 @@ name = "simple"
 required-features = ["netcode"]
 
 [dependencies]
-bevy_app = "0.14"
-bevy_ecs = "0.14"
-bevy_time = "0.14"
+bevy_app = "0.15.0"
+bevy_ecs = "0.15.0"
+bevy_time = "0.15.0"
 renet = { path="../renet", version = "0.0.16", features = ["bevy"] }
 renet_netcode = { path="../renet_netcode", version = "0.0.1", features = ["bevy"], optional = true }
 renet_steam = { path="../renet_steam", version = "0.0.2", features = ["bevy"], optional = true }
 
 [dev-dependencies]
-bevy = {version = "0.14", default-features = false, features = ["bevy_core_pipeline", "bevy_render", "bevy_asset", "bevy_pbr", "x11", "tonemapping_luts", "ktx2", "zstd"]}
+bevy = {version = "0.15.0", default-features = false, features = ["bevy_core_pipeline", "bevy_render", "bevy_asset", "bevy_pbr", "x11", "tonemapping_luts", "ktx2", "zstd"]}
 bincode = "1.3"
 env_logger = "0.11"
 serde = {version = "1.0", features = ["derive"]}

--- a/bevy_renet/Cargo.toml
+++ b/bevy_renet/Cargo.toml
@@ -28,7 +28,7 @@ renet_netcode = { path="../renet_netcode", version = "0.0.1", features = ["bevy"
 renet_steam = { path="../renet_steam", version = "0.0.2", features = ["bevy"], optional = true }
 
 [dev-dependencies]
-bevy = {version = "0.15.0", default-features = false, features = ["bevy_core_pipeline", "bevy_render", "bevy_asset", "bevy_pbr", "x11", "tonemapping_luts", "ktx2", "zstd"]}
+bevy = {version = "0.15.0", default-features = false, features = ["bevy_core_pipeline", "bevy_render", "bevy_asset", "bevy_pbr", "x11", "tonemapping_luts", "ktx2", "zstd", "bevy_window"]}
 bincode = "1.3"
 env_logger = "0.11"
 serde = {version = "1.0", features = ["derive"]}

--- a/bevy_renet/README.md
+++ b/bevy_renet/README.md
@@ -113,8 +113,8 @@ fn receive_message_system(mut client: ResMut<RenetClient>) {
 
 You can run the `simple` example with:
 
-* Server: `cargo run --features="serde transport" --example simple -- server`
-* Client: `cargo run --features="serde transport" --example simple -- client`
+* Server: `cargo run --features="netcode" --example simple -- server`
+* Client: `cargo run --features="netcode" --example simple -- client`
 
 If you want a more complex example you can checkout the [demo_bevy](https://github.com/lucaspoffo/renet/tree/master/demo_bevy) sample:
 

--- a/bevy_renet/README.md
+++ b/bevy_renet/README.md
@@ -13,29 +13,31 @@ Bevy renet is a small layer over the `renet` crate, it adds systems to call the 
 
 #### Server
 ```rust
-let mut app = App::new();
-app.add_plugin(RenetServerPlugin);
+fn main() {
+    let mut app = App::new();
+    app.add_plugin(RenetServerPlugin);
 
-let server = RenetServer::new(ConnectionConfig::default());
-app.insert_resource(server);
+    let server = RenetServer::new(ConnectionConfig::default());
+    app.insert_resource(server);
 
-// Transport layer setup
-app.add_plugin(NetcodeServerPlugin);
-let server_addr = "127.0.0.1:5000".parse().unwrap();
-let socket = UdpSocket::bind(server_addr).unwrap();
-let server_config = ServerConfig {
-    current_time: SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap(),
-    max_clients: 64, 
-    protocol_id: 0,
-    public_addresses: vec![server_addr], 
-    authentication: ServerAuthentication::Unsecure
-};
-let transport = NetcodeServerTransport::new(server_config, socket).unwrap();
-app.insert_resource(transport);
+    // Transport layer setup
+    app.add_plugin(NetcodeServerPlugin);
+    let server_addr = "127.0.0.1:5000".parse().unwrap();
+    let socket = UdpSocket::bind(server_addr).unwrap();
+    let server_config = ServerConfig {
+        current_time: SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap(),
+        max_clients: 64,
+        protocol_id: 0,
+        public_addresses: vec![server_addr],
+        authentication: ServerAuthentication::Unsecure
+    };
+    let transport = NetcodeServerTransport::new(server_config, socket).unwrap();
+    app.insert_resource(transport);
 
-app.add_system(send_message_system);
-app.add_system(receive_message_system);
-app.add_system(handle_events_system);
+    app.add_system(send_message_system);
+    app.add_system(receive_message_system);
+    app.add_system(handle_events_system);
+}
 
 // Systems
 
@@ -71,29 +73,31 @@ fn handle_events_system(mut server_events: EventReader<ServerEvent>) {
 
 #### Client
 ```rust
-let mut app = App::new();
-app.add_plugin(RenetClientPlugin);
+fn main() {
+    let mut app = App::new();
+    app.add_plugin(RenetClientPlugin);
 
-let client = RenetClient::new(ConnectionConfig::default());
-app.insert_resource(client);
+    let client = RenetClient::new(ConnectionConfig::default());
+    app.insert_resource(client);
 
-// Setup the transport layer
-app.add_plugin(NetcodeClientPlugin);
+    // Setup the transport layer
+    app.add_plugin(NetcodeClientPlugin);
 
-let authentication = ClientAuthentication::Unsecure {
-    server_addr: SERVER_ADDR,
-    client_id: 0,
-    user_data: None,
-    protocol_id: 0,
-};
-let socket = UdpSocket::bind("127.0.0.1:0").unwrap();
-let current_time = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap();
-let mut transport = NetcodeClientTransport::new(current_time, authentication, socket).unwrap();
+    let authentication = ClientAuthentication::Unsecure {
+        server_addr: SERVER_ADDR,
+        client_id: 0,
+        user_data: None,
+        protocol_id: 0,
+    };
+    let socket = UdpSocket::bind("127.0.0.1:0").unwrap();
+    let current_time = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap();
+    let mut transport = NetcodeClientTransport::new(current_time, authentication, socket).unwrap();
 
-app.insert_resource(transport);
+    app.insert_resource(transport);
 
-app.add_system(send_message_system);
-app.add_system(receive_message_system);
+    app.add_system(send_message_system);
+    app.add_system(receive_message_system);
+}
 
 // Systems
 

--- a/bevy_renet/examples/simple.rs
+++ b/bevy_renet/examples/simple.rs
@@ -135,12 +135,11 @@ fn server_update_system(
                 println!("Player {} connected.", client_id);
                 // Spawn player cube
                 let player_entity = commands
-                    .spawn(PbrBundle {
-                        mesh: meshes.add(Cuboid::from_size(Vec3::splat(1.0))),
-                        material: materials.add(Color::srgb(0.8, 0.7, 0.6)),
-                        transform: Transform::from_xyz(0.0, 0.5, 0.0),
-                        ..Default::default()
-                    })
+                    .spawn((
+                        Mesh3d(meshes.add(Cuboid::from_size(Vec3::splat(1.0)))),
+                        MeshMaterial3d(materials.add(Color::srgb(0.8, 0.7, 0.6))),
+                        Transform::from_xyz(0.0, 0.5, 0.0),
+                    ))
                     .insert(PlayerInput::default())
                     .insert(Player { id: *client_id })
                     .id();
@@ -202,12 +201,11 @@ fn client_sync_players(
             ServerMessages::PlayerConnected { id } => {
                 println!("Player {} connected.", id);
                 let player_entity = commands
-                    .spawn(PbrBundle {
-                        mesh: meshes.add(Cuboid::from_size(Vec3::splat(1.0))),
-                        material: materials.add(Color::srgb(0.8, 0.7, 0.6)),
-                        transform: Transform::from_xyz(0.0, 0.5, 0.0),
-                        ..Default::default()
-                    })
+                    .spawn((
+                        Mesh3d(meshes.add(Cuboid::from_size(Vec3::splat(1.0)))),
+                        MeshMaterial3d(materials.add(Color::srgb(0.8, 0.7, 0.6))),
+                        Transform::from_xyz(0.0, 0.5, 0.0),
+                    ))
                     .id();
 
                 lobby.players.insert(id, player_entity);
@@ -238,25 +236,23 @@ fn client_sync_players(
 /// set up a simple 3D scene
 fn setup(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>, mut materials: ResMut<Assets<StandardMaterial>>) {
     // plane
-    commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(PlaneMeshBuilder::from_size(Vec2::splat(5.0)))),
-        material: materials.add(Color::srgb(0.3, 0.5, 0.3)),
-        ..Default::default()
-    });
+    commands.spawn((
+        Mesh3d(meshes.add(Mesh::from(PlaneMeshBuilder::from_size(Vec2::splat(5.0))))),
+        MeshMaterial3d(materials.add(Color::srgb(0.3, 0.5, 0.3))),
+    ));
     // light
-    commands.spawn(PointLightBundle {
-        point_light: PointLight {
+    commands.spawn((
+        PointLight {
             shadows_enabled: true,
             ..default()
         },
-        transform: Transform::from_xyz(4.0, 8.0, 4.0),
-        ..default()
-    });
+        Transform::from_xyz(4.0, 8.0, 4.0),
+    ));
     // camera
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..Default::default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
 }
 
 fn player_input(keyboard_input: Res<ButtonInput<KeyCode>>, mut player_input: ResMut<PlayerInput>) {

--- a/demo_bevy/Cargo.toml
+++ b/demo_bevy/Cargo.toml
@@ -15,7 +15,7 @@ netcode = ["bevy_renet/netcode"]
 steam = ["bevy_renet/steam"]
 
 [dependencies]
-bevy = { version = "0.14", default-features = false, features = [
+bevy = { version = "0.15", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_render",
     "bevy_asset",
@@ -27,10 +27,11 @@ bevy = { version = "0.14", default-features = false, features = [
     "serialize",
 ]}
 
+bevy_window = "0.15.0"
 bevy_renet = { path = "../bevy_renet", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3"
-bevy_egui = "0.28"
+bevy_egui = "0.31.1"
 renet_visualizer = { path = "../renet_visualizer", features = ["bevy"] }
 smooth-bevy-cameras = "0.12"
 fastrand = "2.0"

--- a/demo_bevy/Cargo.toml
+++ b/demo_bevy/Cargo.toml
@@ -25,9 +25,9 @@ bevy = { version = "0.15", default-features = false, features = [
     "ktx2",
     "zstd",
     "serialize",
+    "bevy_window"
 ]}
 
-bevy_window = "0.15.0"
 bevy_renet = { path = "../bevy_renet", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3"

--- a/demo_bevy/README.md
+++ b/demo_bevy/README.md
@@ -6,8 +6,8 @@ Simple bevy application to demonstrates how you could replicate entities and sen
 
 Running using the netcode transport:
 
-- server: `cargo run --bin server --features transport`
-- client: `cargo run --bin client --features transport`
+- server: `cargo run --bin server --features netcode`
+- client: `cargo run --bin client --features netcode`
 
 Running using the steam transport:
 

--- a/demo_bevy/src/bin/client.rs
+++ b/demo_bevy/src/bin/client.rs
@@ -5,7 +5,8 @@ use bevy::{
     prelude::*,
     prelude::Vec3
 };
-use bevy_window::{Window, PrimaryWindow};
+use bevy::window::PrimaryWindow;
+use bevy::window::{Window, PrimaryWindow};
 use bevy_egui::{EguiContexts, EguiPlugin};
 use bevy_renet::{
     client_connected,
@@ -302,7 +303,7 @@ fn update_target_system(
 
 fn setup_camera(mut commands: Commands) {
     commands
-        .spawn(LookTransformBundle {
+        .spawn(/*LookTransformBundle {
             transform: LookTransform {
                 eye: Vec3::new(0.0, 8., 2.5),
                 target: Vec3::new(0.0, 0.5, 0.0),
@@ -310,7 +311,7 @@ fn setup_camera(mut commands: Commands) {
             },
             smoother: Smoother::new(0.9),
         })
-        .insert((
+        .insert(*/(
             Camera3d::default(),
             Transform::from_xyz(0., 8.0, 2.5).looking_at(Vec3::new(0.0, 0.5, 0.0), Vec3::Y),
         ));

--- a/demo_bevy/src/bin/client.rs
+++ b/demo_bevy/src/bin/client.rs
@@ -6,13 +6,8 @@ use bevy::{
     prelude::Vec3
 };
 use bevy::window::PrimaryWindow;
-use bevy::window::{Window, PrimaryWindow};
 use bevy_egui::{EguiContexts, EguiPlugin};
-use bevy_renet::{
-    client_connected,
-    renet::{ClientId, RenetClient},
-    RenetClientPlugin,
-};
+use bevy_renet::{client_connected, renet::{ClientId, RenetClient}, RenetClientPlugin};
 use demo_bevy::{
     connection_config, setup_level, ClientChannel, NetworkedEntities, PlayerCommand, PlayerInput, ServerChannel, ServerMessages,
 };

--- a/demo_bevy/src/bin/client.rs
+++ b/demo_bevy/src/bin/client.rs
@@ -12,7 +12,7 @@ use demo_bevy::{
     connection_config, setup_level, ClientChannel, NetworkedEntities, PlayerCommand, PlayerInput, ServerChannel, ServerMessages,
 };
 use renet_visualizer::{RenetClientVisualizer, RenetVisualizerStyle};
-use smooth_bevy_cameras::{LookTransform, LookTransformBundle, LookTransformPlugin, Smoother};
+// use smooth_bevy_cameras::{LookTransform, LookTransformBundle, LookTransformPlugin, Smoother};
 
 #[derive(Component)]
 struct ControlledPlayer;
@@ -122,7 +122,7 @@ fn main() {
     let mut app = App::new();
     app.add_plugins(DefaultPlugins);
     app.add_plugins(RenetClientPlugin);
-    app.add_plugins(LookTransformPlugin);
+    // app.add_plugins(LookTransformPlugin);
     app.add_plugins(FrameTimeDiagnosticsPlugin);
     app.add_plugins(LogDiagnosticsPlugin::default());
     app.add_plugins(EguiPlugin);
@@ -139,7 +139,7 @@ fn main() {
     app.insert_resource(PlayerInput::default());
     app.insert_resource(NetworkMapping::default());
 
-    app.add_systems(Update, (player_input, camera_follow, update_target_system));
+    app.add_systems(Update, (player_input, /*camera_follow,*/ update_target_system));
     app.add_systems(
         Update,
         (client_send_input, client_send_player_commands, client_sync_players).in_set(Connected),
@@ -322,7 +322,7 @@ fn setup_target(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>, mut ma
         .insert(Target);
 }
 
-fn camera_follow(
+/*fn camera_follow(
     mut camera_query: Query<&mut LookTransform, (With<Camera>, Without<ControlledPlayer>)>,
     player_query: Query<&Transform, With<ControlledPlayer>>,
 ) {
@@ -333,3 +333,4 @@ fn camera_follow(
         cam_transform.target = player_transform.translation;
     }
 }
+*/

--- a/demo_bevy/src/bin/server.rs
+++ b/demo_bevy/src/bin/server.rs
@@ -158,12 +158,11 @@ fn server_update_system(
                 // Spawn new player
                 let transform = Transform::from_xyz((fastrand::f32() - 0.5) * 40., 0.51, (fastrand::f32() - 0.5) * 40.);
                 let player_entity = commands
-                    .spawn(PbrBundle {
-                        mesh: meshes.add(Mesh::from(Capsule3d::default())),
-                        material: materials.add(Color::srgb(0.8, 0.7, 0.6)),
+                    .spawn((
+                        Mesh3d(meshes.add(Mesh::from(Capsule3d::default()))),
+                        MeshMaterial3d(materials.add(Color::srgb(0.8, 0.7, 0.6))),
                         transform,
-                        ..Default::default()
-                    })
+                    ))
                     .insert(PlayerInput::default())
                     .insert(Velocity::default())
                     .insert(Player { id: *client_id })
@@ -267,16 +266,16 @@ fn move_players_system(mut query: Query<(&mut Velocity, &PlayerInput)>) {
 
 fn apply_velocity_system(mut query: Query<(&Velocity, &mut Transform)>, time: Res<Time>) {
     for (velocity, mut transform) in query.iter_mut() {
-        transform.translation += velocity.0 * time.delta_seconds();
+        transform.translation += velocity.0 * time.delta_secs();
     }
 }
 
 pub fn setup_simple_camera(mut commands: Commands) {
     // camera
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(-20.5, 30.0, 20.5).looking_at(Vec3::ZERO, Vec3::Y),
-        ..Default::default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(-20.5, 30.0, 20.5).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
 }
 
 fn projectile_on_removal_system(mut server: ResMut<RenetServer>, mut removed_projectiles: RemovedComponents<Projectile>) {
@@ -303,12 +302,11 @@ fn spawn_bot(
         // Spawn new player
         let transform = Transform::from_xyz((fastrand::f32() - 0.5) * 40., 0.51, (fastrand::f32() - 0.5) * 40.);
         let player_entity = commands
-            .spawn(PbrBundle {
-                mesh: meshes.add(Mesh::from(Capsule3d::default())),
-                material: materials.add(Color::srgb(0.8, 0.7, 0.6)),
+            .spawn((
+                Mesh3d(meshes.add(Mesh::from(Capsule3d::default()))),
+                MeshMaterial3d(materials.add(Color::srgb(0.8, 0.7, 0.6))),
                 transform,
-                ..Default::default()
-            })
+            ))
             .insert(Player { id: client_id })
             .insert(Bot {
                 auto_cast: Timer::from_seconds(3.0, TimerMode::Repeating),

--- a/demo_bevy/src/lib.rs
+++ b/demo_bevy/src/lib.rs
@@ -132,25 +132,23 @@ pub fn connection_config() -> ConnectionConfig {
 /// set up a simple 3D scene
 pub fn setup_level(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>, mut materials: ResMut<Assets<StandardMaterial>>) {
     // plane
-    commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(Cuboid::new(40., 1., 40.))),
-        material: materials.add(Color::srgb(0.3, 0.5, 0.3)),
-        transform: Transform::from_xyz(0.0, -1.0, 0.0),
-        ..Default::default()
-    });
+    commands.spawn((
+        Mesh3d(meshes.add(Mesh::from(Cuboid::new(40., 1., 40.)))),
+        MeshMaterial3d(materials.add(Color::srgb(0.3, 0.5, 0.3))),
+        Transform::from_xyz(0.0, -1.0, 0.0),
+    ));
     // light
-    commands.spawn(DirectionalLightBundle {
-        directional_light: DirectionalLight {
+    commands.spawn((
+        DirectionalLight {
             shadows_enabled: true,
             ..default()
         },
-        transform: Transform {
+        Transform {
             translation: Vec3::new(0.0, 2.0, 0.0),
             rotation: Quat::from_rotation_x(-PI / 4.),
             ..default()
         },
-        ..default()
-    });
+    ));
 }
 
 #[derive(Debug, Component)]
@@ -169,12 +167,11 @@ pub fn spawn_fireball(
         direction = Vec3::X;
     }
     commands
-        .spawn(PbrBundle {
-            mesh: meshes.add(Sphere { radius: 0.1 }),
-            material: materials.add(Color::srgb(1.0, 0.0, 0.0)),
-            transform: Transform::from_translation(translation),
-            ..Default::default()
-        })
+        .spawn((
+            Mesh3d(meshes.add(Sphere { radius: 0.1 })),
+            MeshMaterial3d(materials.add(Color::srgb(1.0, 0.0, 0.0))),
+            Transform::from_translation(translation),
+        ))
         .insert(Velocity(direction * 10.))
         .insert(Projectile {
             duration: Timer::from_seconds(1.5, TimerMode::Once),

--- a/demo_chat/Cargo.toml
+++ b/demo_chat/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 renet = { path = "../renet" }
 renet_netcode = { path = "../renet_netcode" }
 renet_visualizer = { path = "../renet_visualizer" }
-eframe = "0.28"
+eframe = "0.29.1"
 serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3"
 log = { version = "0.4", features = ["std"] }

--- a/demo_chat/src/ui.rs
+++ b/demo_chat/src/ui.rs
@@ -61,7 +61,7 @@ pub fn draw_host_commands(ui: &mut Ui, chat_server: &mut ChatServer) {
 
     ui.separator();
 
-    egui::ScrollArea::vertical().id_source("host_commands_scroll").show(ui, |ui| {
+    egui::ScrollArea::vertical().id_salt("host_commands_scroll").show(ui, |ui| {
         for client_id in chat_server.server.clients_id() {
             ui.horizontal(|ui| {
                 ui.label(format!("Client {}", client_id));
@@ -229,7 +229,7 @@ pub fn draw_chat(ui_state: &mut UiState, state: &mut AppState, usernames: HashMa
     egui::CentralPanel::default().show(ctx, |ui| {
         egui::ScrollArea::vertical()
             .auto_shrink([false; 2])
-            .id_source("client_list_scroll")
+            .id_salt("client_list_scroll")
             .show(ui, |ui| {
                 let messages = match state {
                     AppState::HostChat { chat_server: server } => &server.messages,

--- a/renet/Cargo.toml
+++ b/renet/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.0.16"
 bevy = ["dep:bevy_ecs"]
 
 [dependencies]
-bevy_ecs = { version = "0.14", optional = true }
+bevy_ecs = { version = "0.15.0", optional = true }
 bytes = "1.1"
 log = "0.4.17"
 octets = "0.3"

--- a/renet/src/remote_connection.rs
+++ b/renet/src/remote_connection.rs
@@ -10,6 +10,7 @@ use octets::OctetsMut;
 use std::collections::{BTreeMap, HashMap};
 use std::ops::Range;
 use std::time::Duration;
+use bevy_ecs::system::Resource;
 
 /// Configuration for a renet connection and its channels.
 #[derive(Debug, Clone)]
@@ -79,7 +80,7 @@ pub enum RenetConnectionStatus {
 }
 
 #[derive(Debug)]
-#[cfg_attr(feature = "bevy", derive(bevy_ecs::system::Resource))]
+#[cfg_attr(feature = "bevy", derive(Resource))]
 pub struct RenetClient {
     packet_sequence: u64,
     current_time: Duration,

--- a/renet_netcode/Cargo.toml
+++ b/renet_netcode/Cargo.toml
@@ -13,7 +13,7 @@ bevy = ["dep:bevy_ecs"]
 [dependencies]
 renet = { version = "0.0.16", path = "../renet" }
 renetcode = { path = "../renetcode", version = "0.0.12" }
-bevy_ecs = { version = "0.14", optional = true }
+bevy_ecs = { version = "0.15.0", optional = true }
 log = "0.4.19"
 
 [dev-dependencies]

--- a/renet_steam/Cargo.toml
+++ b/renet_steam/Cargo.toml
@@ -17,7 +17,7 @@ bevy = ["dep:bevy_ecs"]
 renet = { version = "0.0.16", path = "../renet" }
 steamworks = "0.11"
 log = "0.4.19"
-bevy_ecs = { version = "0.14", optional = true }
+bevy_ecs = { version = "0.15.0", optional = true }
 
 [dev-dependencies]
 env_logger = "0.11"

--- a/renet_visualizer/Cargo.toml
+++ b/renet_visualizer/Cargo.toml
@@ -14,5 +14,5 @@ bevy = ["dep:bevy_ecs"]
 
 [dependencies]
 renet = { path = "../renet", version = "0.0.16" }
-egui = "0.28"
-bevy_ecs = { version = "0.14", optional = true }
+egui = "0.29.1"
+bevy_ecs = { version = "0.15.0", optional = true }


### PR DESCRIPTION
I needed `bevy_renet` for my bevy apps, so I have updated `bevy` to version 0.15 for all packages.

I also ported to `bevy:0.15` the bevy examples and updated READMEs to specify the correct cargo features to run the examples.

The client for demo_bevy example requires a version update from `smooth-bevy-cameras` because `glam `version differs between the `smooth-bevy-cameras:0.12` and `bevy:0.15` crates; `LookTransformPlugin` and associated functions have been commented to be able to successfully compile this example.

The `bevy_renet` crate has been tested on one of my app and works correctly with `bevy:0.15`. 
The "simple" example works correctly with server and client.
The `demo_bevy` example's server runs, but the client needs `smooth-bevy-cameras:0.13`

All tests pass with `cargo test`.

The branch is ready to merge, but feel free to wait until `smooth-bevy-cameras:0.13` is available 