### PR TITLE
Set current_time to absolute system time to prevent drift

### DIFF
--- a/demo_bevy/src/bin/client.rs
+++ b/demo_bevy/src/bin/client.rs
@@ -8,12 +8,11 @@ use bevy::{
 };
 use bevy_egui::{EguiContexts, EguiPlugin};
 use bevy_renet::{
-    client_connected,
     renet::{ClientId, RenetClient},
     RenetClientPlugin,
 };
 use demo_bevy::{
-    connection_config, setup_level, ClientChannel, NetworkedEntities, PlayerCommand, PlayerInput, ServerChannel, ServerMessages,
+    setup_level, ClientChannel, NetworkedEntities, PlayerCommand, PlayerInput, ServerChannel, ServerMessages,
 };
 use renet_visualizer::{RenetClientVisualizer, RenetVisualizerStyle};
 

--- a/renet_netcode/src/client.rs
+++ b/renet_netcode/src/client.rs
@@ -84,7 +84,7 @@ impl NetcodeClientTransport {
     }
 
     /// Advances the transport by the duration, and receive packets from the network.
-    pub fn update(&mut self, duration: Duration, client: &mut RenetClient) -> Result<(), NetcodeTransportError> {
+    pub fn update(&mut self, _duration: Duration, client: &mut RenetClient) -> Result<(), NetcodeTransportError> {
         if let Some(reason) = self.netcode_client.disconnect_reason() {
             // Mark the client as disconnected if an error occured in the transport layer
             client.disconnect_due_to_transport();
@@ -124,7 +124,7 @@ impl NetcodeClientTransport {
             }
         }
 
-        if let Some((packet, addr)) = self.netcode_client.update(duration) {
+        if let Some((packet, addr)) = self.netcode_client.update() {
             self.socket.send_to(packet, addr)?;
         }
 

--- a/renetcode/examples/echo.rs
+++ b/renetcode/examples/echo.rs
@@ -175,7 +175,6 @@ fn client(authentication: ClientAuthentication) {
     let stdin_channel = spawn_stdin_channel();
     let mut buffer = [0u8; NETCODE_MAX_PACKET_BYTES];
 
-    let mut last_updated = Instant::now();
     loop {
         if let Some(err) = client.disconnect_reason() {
             panic!("Client error: {:?}", err);
@@ -212,10 +211,9 @@ fn client(authentication: ClientAuthentication) {
             };
         }
 
-        if let Some((packet, addr)) = client.update(Instant::now() - last_updated) {
+        if let Some((packet, addr)) = client.update() {
             udp_socket.send_to(packet, addr).unwrap();
         }
-        last_updated = Instant::now();
         thread::sleep(Duration::from_millis(50));
     }
 }

--- a/renetcode/src/server.rs
+++ b/renetcode/src/server.rs
@@ -762,7 +762,7 @@ mod tests {
         .unwrap();
         let client_auth = ClientAuthentication::Secure { connect_token };
         let mut client = NetcodeClient::new(Duration::ZERO, client_auth).unwrap();
-        let (client_packet, _) = client.update(Duration::ZERO).unwrap();
+        let (client_packet, _) = client.update().unwrap();
 
         let result = server.process_packet(client_addr, client_packet);
         assert!(matches!(result, ServerResult::PacketToSend { .. }));
@@ -772,7 +772,7 @@ mod tests {
         };
 
         assert!(!client.is_connected());
-        let (client_packet, _) = client.update(Duration::ZERO).unwrap();
+        let (client_packet, _) = client.update().unwrap();
         let result = server.process_packet(client_addr, client_packet);
 
         match result {


### PR DESCRIPTION
# Prevent current time update from drifting

## Current setup

The current_time gets updated by a fixed amount every system tick. This is error prone especially for long running sessions, like described in #157.


## Proposal

Instead of having the delay be updated by an relative amount, the current_time should be set to an absolute value in order to prevent a drift of the internal clock.

In addition to setting the current_time at the beginning of the session, the current_time should be updated on every tick accordingly.

## Problems / Considerations

* Maybe there are reasons as to why the client and server clocks should not stay in sync.
* Maybe there are situations where it is expected for the duration to be set manually.

## Alternatives

* Introduce a flag like `auto_sync` which periodically updates the client and server time to current system time, to avoid drifting.