### PR TITLE
RenetVisualizer: Fixes panic when max value is 0 in visualizer

### DIFF
--- a/renet_visualizer/src/lib.rs
+++ b/renet_visualizer/src/lib.rs
@@ -382,7 +382,7 @@ fn show_graph(
             .enumerate()
             .map(|(i, value)| {
                 let x = remap(i as f32, 0.0..=size as f32, 0.0..=style.width);
-                let y = remap(*value, min..=max, 0.0..=style.height);
+                let y = if max == 0.0 { 0.0 } else { remap(*value, min..=max, 0.0..=style.height) };
 
                 pos2(x + init_point.x, init_point.y - y)
             })


### PR DESCRIPTION
This bug is reproducible in the bevy_demo example:

1.  Run `cargo run --bin server --features netcode`
2.  Make sure the  `Show all clients` is checked
3. Run `cargo run --bin client --features netcode`

I get the following crash

````
2025-02-22T15:58:57.015140Z  INFO bevy diagnostic: frame_count: 3593.000000   (avg 3533.500000)
Player 1740239936136 connected.
thread 'main' panicked at C:\Users\JF\.cargo\registry\src\index.crates.io-6f17d22bba15001f\emath-0.29.1\src\lib.rs:148:5:
assertion failed: from.start() != from.end()
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Encountered a panic in system `server::update_visulizer_system`!
2025-02-22T15:58:57.832135Z  WARN bevy_ecs::world::command_queue: CommandQueue has un-applied commands being dropped. Did you forget to call SystemState::apply?
Encountered a panic in system `bevy_app::main_schedule::Main::run_main`!
error: process didn't exit successfully: `F:\programming\renet\target\debug\server.exe` (exit code: 101)
`````

