### PR TITLE
Derive `Debug` and `Clone` on `DefaultChannel`

### DIFF
--- a/renet/src/channel/mod.rs
+++ b/renet/src/channel/mod.rs
@@ -38,6 +38,7 @@ pub struct ChannelConfig {
 
 /// Utility enumerator when using the default channels configuration.
 /// The default configuration has 3 channels: unreliable, reliable ordered, and reliable unordered.
+#[derive(Debug, Clone)]
 pub enum DefaultChannel {
     Unreliable,
     ReliableOrdered,


### PR DESCRIPTION
Mainly for ease of use