### PR TITLE
Expose `NETCODE_MAX_CLIENTS`

### DIFF
--- a/renetcode/src/lib.rs
+++ b/renetcode/src/lib.rs
@@ -34,7 +34,7 @@ pub use token::{ConnectToken, TokenGenerationError};
 use std::time::Duration;
 
 const NETCODE_VERSION_INFO: &[u8; 13] = b"NETCODE 1.02\0";
-const NETCODE_MAX_CLIENTS: usize = 1024;
+pub const NETCODE_MAX_CLIENTS: usize = 1024;
 const NETCODE_MAX_PENDING_CLIENTS: usize = NETCODE_MAX_CLIENTS * 4;
 
 const NETCODE_ADDRESS_NONE: u8 = 0;


### PR DESCRIPTION
Prevents consumers from having to hard code 1024 as the default value when maximum clients are not specified