### PR TITLE
Use `Time<Real>`

### DIFF
--- a/bevy_renet/src/lib.rs
+++ b/bevy_renet/src/lib.rs
@@ -48,7 +48,7 @@ impl Plugin for RenetServerPlugin {
 }
 
 impl RenetServerPlugin {
-    pub fn update_system(mut server: ResMut<RenetServer>, time: Res<Time>) {
+    pub fn update_system(mut server: ResMut<RenetServer>, time: Res<Time<Real>>) {
         server.update(time.delta());
     }
 
@@ -66,7 +66,7 @@ impl Plugin for RenetClientPlugin {
 }
 
 impl RenetClientPlugin {
-    pub fn update_system(mut client: ResMut<RenetClient>, time: Res<Time>) {
+    pub fn update_system(mut client: ResMut<RenetClient>, time: Res<Time<Real>>) {
         client.update(time.delta());
     }
 }

--- a/bevy_renet/src/netcode.rs
+++ b/bevy_renet/src/netcode.rs
@@ -53,7 +53,7 @@ impl NetcodeServerPlugin {
         mut commands: Commands,
         mut transport: ResMut<NetcodeServerTransport>,
         mut server: ResMut<RenetServer>,
-        time: Res<Time>,
+        time: Res<Time<Real>>,
     ) {
         if let Err(e) = transport.update(time.delta(), &mut server) {
             commands.trigger(NetcodeErrorEvent(e));
@@ -107,7 +107,7 @@ impl NetcodeClientPlugin {
         mut commands: Commands,
         mut transport: ResMut<NetcodeClientTransport>,
         mut client: ResMut<RenetClient>,
-        time: Res<Time>,
+        time: Res<Time<Real>>,
     ) {
         if let Err(e) = transport.update(time.delta(), &mut client) {
             commands.trigger(NetcodeErrorEvent(e));


### PR DESCRIPTION
By default, `Time` refers to `Time<Virtual>`, which is affected by time dilation.
This means that doing things like pausing will break `renet`. I replaced it with `Time<Real>`, which uses real time.